### PR TITLE
Add parameter and assumption documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,12 @@ PFLCM (short for Paid Family Leave Cost Model) is a model to evaluate the total 
 ## Disclaimer
 This model is currently under development. The model components and the results may change as the model improves.
 
-## Set-up Instructions
-FMLA Public Use File
- - Download the Public Use File for Employees from the Department of Labor: https://www.dol.gov/whd/fmla/survey/
- - Extract the .dta version of the dataset and save it in this repository as `fmla.dta`.
+## Documentation
+[Set-up instructions](https://github.com/open-source-economics/PFLCM/blob/master/documentation/setup_instructions.md)
 
-CPS Public Use File
- - Download and extract the March 2017 CPS ASEC dataset here: http://www.nber.org/cps/cpsmar2017.zip
- - Save as a .dct file the March 2017 CPS data dictionary here: http://www.nber.org/data/progs/cps/cpsmar2017.dct
- - Read the CPS data into Stata using the following command:
-   - `infile using "cpsmar2017.dct", using("asec2017_pubuse.dat")`
- - Once it has been converted, save the CPS dataset in this repository as `cpsmar2017.dta`.
+[Documentation of policy parameters](https://github.com/open-source-economics/PFLCM/blob/master/documentation/policy_parameters.md)
+
+[Documentation of program take-up assumptions](https://github.com/open-source-economics/PFLCM/blob/master/documentation/takeup_assumptions.md)
 
 ## Citing PFLCM
 PFLCM (Version 0.0.0)[Source code], https://github.com/open-source-economics/PFLCM.

--- a/documentation/policy_parameters.md
+++ b/documentation/policy_parameters.md
@@ -1,0 +1,64 @@
+# Policy parameters
+
+## Leave duration parameters
+`maxduration_days`
+ - Definition: Maximum duration of days receiving paid leave benefits, annual basis
+ - Limitations:
+   - Minimum: parameter value must exceed 0 (strict requirement)
+   - Maximum: parameter value should not exceed 121 days (recommendation)
+
+`waiting_period`
+ - Definition: Days between leave needed when leave is eligible for paid leave benefits
+ - Limitations:
+   - Minimum: parameter value should be nonnegative (recommendation)
+   - Maximum: parameter value should not exceed 20 days (recommendation)
+
+## Payment parameters
+`replacementrate`
+ - Definition: Proportion of usual wages paid during leave, weekly basis while on program
+ - Limitations:
+   - Minimum: parameter value should not be negative (recommendation)
+
+`maxbenefit`
+ - Definition: Maximum weekly benefit amount
+ - Limitations:
+   - Mimumum: parameter value should not be negative (recommendation)
+
+## Eligibility requirements
+`work_requirement`
+ - Definition: Minimum total hours worked (annual basis) to be eligible for paid leave benefits
+ - Limitations:
+   - Minimum: parameter value should not be negative (recommendation)
+
+## Types of leave included
+`include_ownhealth`
+ - Definition: Whether paid leave program includes own medical leave (1 for yes, 0 for no)
+ - Limitations: possible values of 0 or 1
+
+`include_childhealth`
+ - Definition: Whether paid leave program includes leave to care for one's ill child (1 for yes, 0 for no)
+ - Limitations: possible values of 0 or 1
+
+`include_spousehealth`
+ - Definition: Whether paid leave program includes leave to care for one's ill spouse (1 for yes, 0 for no)
+ - Limitations: possible values of 0 or 1
+
+`include_parenthealth`
+ - Definition: Whether paid leave program includes leave to care for one's ill parent (1 for yes, 0 for no)
+ - Limitations: possible values of 0 or 1
+
+`include_otherrelhealth`
+ - Definition: Whether paid leave program includes leave to care for a relative besides child, spouse or parent (1 for yes, 0 for no)
+ - Limitations: possible values of 0 or 1
+
+`include_military`
+ - Definition: Whether paid leave program includes leave to address issues from deployment of a military member (1 for yes, 0 for no)
+ - Limitations: possible values of 0 or 1
+
+`include_otherreason`
+ - Definition: Whether paid leave program includes leave for other reasons (1 for yes, 0 for no)
+ - Limitations: possible values of 0 or 1
+
+`include_newchild`
+ - Definition: Whether paid leave program includes parental leave (1 for yes, 0 for no)
+ - Limitations: possible values of 0 or 1

--- a/documentation/setup_instructions.md
+++ b/documentation/setup_instructions.md
@@ -1,0 +1,13 @@
+# Set-up Instructions
+This file explains how to download and set up the necessary datasets to run PFLCM.
+
+## FMLA Public Use File
+ - Download the Public Use File for Employees from the Department of Labor: https://www.dol.gov/whd/fmla/survey/
+ - Extract the .dta version of the dataset and save it in this repository as `fmla.dta`.
+
+## CPS Public Use File
+ - Download and extract the March 2017 CPS ASEC dataset here: http://www.nber.org/cps/cpsmar2017.zip
+ - Save as a .dct file the March 2017 CPS data dictionary here: http://www.nber.org/data/progs/cps/cpsmar2017.dct
+ - Read the CPS data into Stata using the following command:
+     `infile using "cpsmar2017.dct", using("asec2017_pubuse.dat")`
+ - Once it has been converted, save the CPS dataset in this repository as `cpsmar2017.dta`.

--- a/documentation/takeup_assumptions.md
+++ b/documentation/takeup_assumptions.md
@@ -1,0 +1,64 @@
+# Program Use Assumptions
+
+## Headline take-up rate
+`overall_takeup`
+ - Definition: Probability of taking leave
+ - Recommended value: 0.159
+   - Source: Fraction of employees who took leave the last 12 months, among FMLA eligible and covered employees, from [Klerman, Daley and Pozniak, (2012)](https://www.dol.gov/asp/evaluation/fmla/FMLA-2012-Technical-Report.pdf).
+ - Limitations:
+   - Minimum: 0
+   - Maximum: 1
+
+## Reduced take-up assumptions
+These parameters reduce the take-up rates for different types of leave. The parametes apply to each type of leave:
+ - `reduce_ownhealth`: own medical leave
+ - `reduce_childhealth`: leave to care for an ill child
+ - `reduce_spousehealth`: leave to care for an ill spouse
+ - `reduce_parenthealth`: leave to care for an ill parent
+ - `reduce_otherrelhealth`: leave to care for an ill relative, excluding child, spouse or parent
+ - `reduce_military`: leave to address issues from the deployment of a military member
+ - `reduce_newchild`: leave for the birth of a new child
+ - `reduce_otherreason`: leave for other reasons
+
+Recommended values: 
+ - Full take-up: Every person who take leave and is eligible for the paid leave program uses it.
+   - Values:
+     - `reduce_ownhealth = 1`
+     - `reduce_childhealth = 1`
+     - `reduce_spousehealth = 1`
+     - `reduce_parenthealth = 1`
+     - `reduce_otherelhealth = 1`
+     - `reduce_military = 1`
+     - `reduce_otherreason = 1`
+     - `reduce_newchild = 1`
+ - Reduced take-up: Not all individuals who take leave and are eligible for the paid leave program use it, based on observed lower take-up rates in the state programs.
+     - `reduce_ownhealth = 0.5`
+     - `reduce_childhealth = 0.2`
+     - `reduce_spousehealth = 0.2`
+     - `reduce_parenthealth = 0.1`
+     - `reduce_otherelhealth = 0.1`
+     - `reduce_military = 0.9`
+     - `reduce_otherreason = 0`
+     - `reduce_newchild = 0.9`
+For a description of these and a comparison, see Gitis, Glynn and Hayes (2018) (forthcoming).
+
+Limitations: 
+ - Minimum: 0
+ - Maximum: 1
+
+## Employer push assumptions
+This parameter how employers respond to the creation of a paid leave program. 
+ - Employer who do not pay their employees while on leave do not respond.
+ - Some employers who provide paid leave would push their employees onto the government program immediately. If the employer offers a more generous benefit, the employer may top up the benefit.
+ - Some employers who provide paid leave would continue to provide it for a short period before pushing employees onto the government program. We assume that this would occur after 4 weeks.
+
+`frac_employerpush`
+ - Defition: The proportion of employees who already receive pay while on leave that are immediately pushed onto the government program.
+ - Note: The proportion that continues to receive pay from their employer but not the government program for the first 4 weeks is `1 - frac_employerpush`. 
+ - Recommended values:
+   - Full employer push: `frac_employerpush = 1`
+   - Reduced employer push: `frac_employerpush = 0.4`
+   - For a description of these and a comparison, see Gitis, Glynn and Hayes (2018) (forthcoming)
+ - Limitations:
+   - Minimum: 0
+   - Maximum: 1


### PR DESCRIPTION
This PR adds documentation for the parameters and assumptions. It also separates the set-up instructions into a separate file in the `documentation` folder. The README file now includes links to the documentation. However, the links in the README file will not work until this PR has been merged.

Subsequent additional documentation will include descriptions of how each section of the model works, and an explanation of how to use the model. 

@begitis @MattHJensen 