### PR TITLE
Add tests

### DIFF
--- a/tests/test_assumptions.do
+++ b/tests/test_assumptions.do
@@ -1,0 +1,304 @@
+cd ..
+
+/*
+This file tests the effects of changing the assumptions.
+It begins with a base case and tests the results when 
+each assumption value deviates from the base case. 
+*/
+quietly{
+/* Define parameters for base case */
+use parameters, clear
+replace maxduration_days = 40
+replace replacementrate = 0.7
+replace maxbenefit = 600
+replace waiting_period = 0
+replace work_requirement = 0
+replace include_ownhealth = 1
+replace include_childhealth = 1
+replace include_spousehealth = 1
+replace include_parenthealth = 1
+replace include_otherrelhealth = 1
+replace include_military = 1
+replace include_otherreason = 1
+replace include_newchild = 1
+save parameters, replace
+
+
+/* Determine assumptions for all tests */
+use assumptions, clear
+replace overall_takeup = 0.159
+replace reduce_ownhealth = 1.0
+replace reduce_childhealth = 1.0
+replace reduce_spousehealth = 1.0
+replace reduce_parenthealth = 1.0
+replace reduce_otherrelhealth = 1.0
+replace reduce_military = 1.0
+replace reduce_otherreason = 1.0
+replace reduce_newchild = 1.0
+replace frac_employerpush = 1.0
+save assumptions, replace
+}
+
+/* Test base case*/
+quietly {
+do "run_anyassumptions.do"
+gen pass_basecase_expben = (abs(expectedbenefit - 313.13403) < 0.01)
+gen pass_basecase_total = (abs(totalcost/10^9 - 49.870676) < 0.01)
+gen pass_basecase_payroll = (abs(payrollcost*100 - 0.5770769) < 0.01)
+drop expectedbenefit totalcost payrollcost
+gen mergeid = 1
+save "tests/test_assum_basecase_output.dta", replace
+}
+
+/* Test overall_takeup */
+quietly {
+use assumptions, clear
+replace overall_takeup = 0.2
+save assumptions, replace
+do "run_anyassumptions.do"
+gen pass_takeup_expben = (abs(expectedbenefit - 393.8793) < 0.01)
+gen pass_takeup_total = (abs(totalcost/10^9 - 62.730408) < 0.01)
+gen pass_takeup_payroll = (abs(payrollcost*100 - 0.72588287) < 0.01)
+drop expectedbenefit totalcost payrollcost
+gen mergeid = 1
+save "tests/test_assum_takeup_output.dta", replace
+}
+
+/* Test reduce_ownhealth */
+quietly {
+use assumptions, clear
+replace overall_takeup = 0.159
+replace reduce_ownhealth = 0.5
+save assumptions, replace
+do "run_anyassumptions.do"
+gen pass_redmedical_expben = (abs(expectedbenefit - 220.1012 ) < 0.01)
+gen pass_redmedical_total = (abs(totalcost/10^9 - 35.053978) < 0.01)
+gen pass_redmedical_payroll = (abs(payrollcost*100 - .40562595) < 0.01)
+drop expectedbenefit totalcost payrollcost
+gen mergeid = 1
+save "tests/test_assum_redmedical_output.dta", replace
+}
+
+/* Test reduce_childhealth */
+quietly {
+use assumptions, clear
+replace reduce_ownhealth = 1.0
+replace reduce_childhealth = 0.2
+save assumptions, replace
+do "run_anyassumptions.do"
+gen pass_redchildh_expben = (abs(expectedbenefit - 307.3982  ) < 0.01)
+gen pass_redchildh_total = (abs(totalcost/10^9 - 48.957166) < 0.01)
+gen pass_redchildh_payroll = (abs(payrollcost*100 - .56650625) < 0.01)
+drop expectedbenefit totalcost payrollcost
+gen mergeid = 1
+save "tests/test_assum_redchildh_output.dta", replace
+}
+
+/* Test reduce_spousehealth */
+quietly {
+use assumptions, clear
+replace reduce_childhealth = 1.0
+replace reduce_spousehealth = 0.2
+save assumptions, replace
+do "run_anyassumptions.do"
+gen pass_redspouse_expben = (abs(expectedbenefit - 301.0782) < 0.01)
+gen pass_redspouse_total = (abs(totalcost/10^9 - 47.950623) < 0.01)
+gen pass_redspouse_payroll = (abs(payrollcost*100 - .55485908) < 0.01)
+drop expectedbenefit totalcost payrollcost
+gen mergeid = 1
+save "tests/test_assum_redspouse_output.dta", replace
+}
+
+/* Test reduce_parenthealth */
+quietly {
+use assumptions, clear
+replace reduce_spousehealth = 1.0
+replace reduce_parenthealth = 0.1
+save assumptions, replace
+do "run_anyassumptions.do"
+gen pass_redparent_expben = (abs(expectedbenefit - 298.7396) < 0.01)
+gen pass_redparent_total = (abs(totalcost/10^9 - 47.578178) < 0.01)
+gen pass_redparent_payroll = (abs(payrollcost*100 - .55054934) < 0.01)
+drop expectedbenefit totalcost payrollcost
+gen mergeid = 1
+save "tests/test_assum_redparent_output.dta", replace
+}
+
+/* Test reduce_otherrelhealth */
+quietly {
+use assumptions, clear
+replace reduce_parenthealth = 1.0
+replace reduce_otherrelhealth = 0.1
+save assumptions, replace
+do "run_anyassumptions.do"
+gen pass_redotherrel_expben = (abs(expectedbenefit - 309.5474) < 0.01)
+gen pass_redotherrel_total = (abs(totalcost/10^9 - 49.29946) < 0.01)
+gen pass_redotherrel_payroll = (abs(payrollcost*100 - .57046711) < 0.01)
+drop expectedbenefit totalcost payrollcost
+gen mergeid = 1
+save "tests/test_assum_redotherrel_output.dta", replace
+}
+
+/* Test reduce_military */
+quietly {
+use assumptions, clear
+replace reduce_otherrelhealth = 1.0
+replace reduce_military = 0.9
+save assumptions, replace
+do "run_anyassumptions.do"
+gen pass_redmilitary_expben = (abs(expectedbenefit - 312.691) < 0.01)
+gen pass_redmilitary_total = (abs(totalcost/10^9 - 49.80011) < 0.01)
+gen pass_redmilitary_payroll = (abs(payrollcost*100 - .57626031) < 0.01)
+drop expectedbenefit totalcost payrollcost
+gen mergeid = 1
+save "tests/test_assum_redmilitary_output.dta", replace
+}
+
+/* Test reduce_otherreason */
+quietly {
+use assumptions, clear
+replace reduce_military = 1.0
+replace reduce_otherreason = 0.0
+save assumptions, replace
+do "run_anyassumptions.do"
+gen pass_redother_expben = (abs(expectedbenefit - 312.1819) < 0.01)
+gen pass_redother_total = (abs(totalcost/10^9 - 49.719038) < 0.01)
+gen pass_redother_payroll = (abs(payrollcost*100 - .57532224) < 0.01)
+drop expectedbenefit totalcost payrollcost
+gen mergeid = 1
+save "tests/test_assum_redother_output.dta", replace
+}
+
+/* Test reduce_newchild */
+quietly {
+use assumptions, clear
+replace reduce_otherreason = 1.0
+replace reduce_newchild = 0.9
+save assumptions, replace
+do "run_anyassumptions.do"
+gen pass_rednewchild_expben = (abs(expectedbenefit - 305.1873) < 0.01)
+gen pass_rednewchild_total = (abs(totalcost/10^9 - 48.605061) < 0.01)
+gen pass_rednewchild_payroll = (abs(payrollcost*100 - .5624319) < 0.01)
+drop expectedbenefit totalcost payrollcost
+gen mergeid = 1
+save "tests/test_assum_rednewchild_output.dta", replace
+}
+
+/* Test frac_employerpush */
+quietly {
+use assumptions, clear
+replace reduce_newchild = 1.0
+replace frac_employerpush = 0.4
+save assumptions, replace
+do "run_anyassumptions.do"
+gen pass_emppush_expben = (abs(expectedbenefit - 216.7027) < 0.01)
+gen pass_emppush_total = (abs(totalcost/10^9 - 34.512732) < 0.01)
+gen pass_emppush_payroll = (abs(payrollcost*100 - .39936295) < 0.01)
+drop expectedbenefit totalcost payrollcost
+gen mergeid = 1
+save "tests/test_assum_emppush_output.dta", replace
+}
+
+/* Check that all tests pass, or which fail */
+quietly{
+use "tests/test_assum_basecase_output.dta", clear
+gen pass_basecase = pass_basecase_expben * pass_basecase_total * pass_basecase_payroll
+if pass_basecase==1 {
+noisily di "Base case passes"
+}
+else {
+noisily di "Base case fails"
+noisily sum pass_basecase_expben pass_basecase_total pass_basecase_payroll
+}
+merge 1:1 mergeid using "tests/test_assum_takeup_output.dta", nogen norep
+gen pass_takeup = pass_takeup_expben * pass_takeup_total * pass_takeup_payroll
+if pass_takeup == 1 {
+noisily di "Overall take-up assumption passes"
+}
+else {
+noisily di "Overall take-up assumption fails"
+noisily sum pass_takeup_expben pass_takeup_total pass_takeup_payroll
+}
+merge 1:1 mergeid using "tests/test_assum_redmedical_output.dta", nogen norep
+gen pass_redmedical = pass_redmedical_expben * pass_redmedical_total * pass_redmedical_payroll
+if pass_redmedical == 1 {
+noisily di "Reduce take-up for ownhealth assumption passes"
+}
+else {
+noisily di "Reduce take-up for ownhealth assumption fails"
+noisily sum pass_redmedical_expben pass_redmedical_total pass_redmedical_payroll
+}
+merge 1:1 mergeid using "tests/test_assum_redchildh_output.dta", nogen norep
+gen pass_redchildh = pass_redchildh_expben * pass_redchildh_total * pass_redchildh_payroll
+if pass_redchildh == 1 {
+noisily di "Reduce take-up for child health assumption passes"
+}
+else {
+noisily di "Reduce take-up for child health assumption fails"
+noisily sum pass_redchildh_expben pass_redchildh_total pass_redchildh_payroll
+}
+merge 1:1 mergeid using "tests/test_assum_redspouse_output.dta", nogen norep
+gen pass_redspouse = pass_redspouse_expben * pass_redspouse_total * pass_redspouse_payroll
+if pass_redspouse == 1 {
+noisily di "Reduce take-up for spouse health assumption passes"
+}
+else {
+noisily di "Reduce take-up for spouse health assumption fails"
+noisily sum pass_redspouse_expben pass_redspouse_total pass_redspouse_payroll
+}
+merge 1:1 mergeid using "tests/test_assum_redparent_output.dta", nogen norep
+gen pass_redparent = pass_redparent_expben * pass_redparent_total * pass_redparent_payroll
+if pass_redparent == 1 {
+noisily di "Reduce take-up for parent health assumption passes"
+}
+else {
+noisily di "Reduce take-up for parent health assumption fails"
+noisily sum pass_redparent_expben pass_redparent_total pass_redparent_payroll
+}
+merge 1:1 mergeid using "tests/test_assum_redotherrel_output.dta", nogen norep
+gen pass_redotherrel = pass_redotherrel_expben * pass_redotherrel_total * pass_redotherrel_payroll
+if pass_redotherrel == 1 {
+noisily di "Reduce take-up for other relative health assumption passes"
+}
+else {
+noisily di "Reduce take-up for other relative health assumption fails"
+noisily sum pass_redotherrel_expben pass_redotherrel_total pass_redotherrel_payroll
+}
+merge 1:1 mergeid using "tests/test_assum_redmilitary_output.dta", nogen norep
+gen pass_redmilitary = pass_redmilitary_expben * pass_redmilitary_total * pass_redmilitary_payroll
+if pass_redmilitary == 1 {
+noisily di "Reduce take-up for military assumption passes"
+}
+else {
+noisily di "Reduce take-up for military assumption fails"
+noisily sum pass_redmilitary_expben pass_redmilitary_total pass_redmilitary_payroll
+}
+merge 1:1 mergeid using "tests/test_assum_redother_output.dta", nogen norep
+gen pass_redother = pass_redother_expben * pass_redother_total * pass_redother_payroll
+if pass_redother == 1 {
+noisily di "Reduce take-up for other reason assumption passes"
+}
+else {
+noisily di "Reduce take-up for other reason assumption fails"
+noisily sum pass_redother_expben pass_redother_total pass_redother_payroll
+}
+merge 1:1 mergeid using "tests/test_assum_rednewchild_output.dta", nogen norep
+gen pass_rednewchild = pass_rednewchild_expben * pass_rednewchild_total * pass_rednewchild_payroll
+if pass_rednewchild == 1 {
+noisily di "Reduce take-up for new child assumption passes"
+}
+else {
+noisily di "Reduce take-up for new child assumption fails"
+noisily sum pass_rednewchild_expben pass_rednewchild_total pass_rednewchild_payroll
+}
+merge 1:1 mergeid using "tests/test_assum_emppush_output.dta", nogen norep
+gen pass_emppush = pass_emppush_expben * pass_emppush_total * pass_emppush_payroll
+if pass_emppush == 1 {
+noisily di "Reduced employer push assumption passes"
+}
+else {
+noisily di "Reduced employer push assumption fails"
+noisily sum pass_emppush_expben pass_emppush_total pass_emppush_payroll
+}
+}
+

--- a/tests/test_parameters.do
+++ b/tests/test_parameters.do
@@ -1,0 +1,378 @@
+cd ..
+
+/*
+This file tests the effects of changing the parameter 
+values. It begins with a base case and tests the 
+results when each parameter deviates from the 
+base case. 
+*/
+quietly{
+/* Define parameters for base case */
+use parameters, clear
+replace maxduration_days = 40
+replace replacementrate = 0.7
+replace maxbenefit = 600
+replace waiting_period = 0
+replace work_requirement = 0
+replace include_ownhealth = 1
+replace include_childhealth = 1
+replace include_spousehealth = 1
+replace include_parenthealth = 1
+replace include_otherrelhealth = 1
+replace include_military = 1
+replace include_otherreason = 1
+replace include_newchild = 1
+save parameters, replace
+
+
+/* Determine assumptions for all tests */
+use assumptions, clear
+replace overall_takeup = 0.159
+replace reduce_ownhealth = 1.0
+replace reduce_childhealth = 1.0
+replace reduce_spousehealth = 1.0
+replace reduce_parenthealth = 1.0
+replace reduce_otherrelhealth = 1.0
+replace reduce_military = 1.0
+replace reduce_otherreason = 1.0
+replace reduce_newchild = 1.0
+replace frac_employerpush = 1.0
+save assumptions, replace
+}
+
+/* Test base case*/
+quietly {
+do "run_anyassumptions.do"
+gen pass_basecase_expben = (abs(expectedbenefit - 313.13403) < 0.01)
+gen pass_basecase_total = (abs(totalcost/10^9 - 49.870676) < 0.01)
+gen pass_basecase_payroll = (abs(payrollcost*100 - 0.5770769) < 0.01)
+drop expectedbenefit totalcost payrollcost
+gen mergeid = 1
+save "tests/test_params_basecase_output.dta", replace
+}
+
+/* Test maxduration_days */
+quietly {
+use parameters, clear
+replace maxduration_days = 80
+save parameters, replace
+do "run_anyassumptions.do"
+gen pass_duration_expben = (abs(expectedbenefit - 411.77203) < 0.01)
+gen pass_duration_total = (abs(totalcost/10^9 - 65.580061) < 0.01)
+gen pass_duration_payroll = (abs(payrollcost*100 - 0.75885751) < 0.01)
+drop expectedbenefit totalcost payrollcost
+gen mergeid = 1
+save "tests/test_params_duration_output.dta", replace
+}
+
+/* Test replacementrate */
+quietly {
+use parameters, clear
+replace maxduration_days = 40
+replace replacementrate = 0.9
+save parameters, replace
+do "run_anyassumptions.do"
+gen pass_replacement_expben = (abs(expectedbenefit - 341.86853) < 0.01)
+gen pass_replacement_total = (abs(totalcost/10^9 - 54.447018) < 0.01)
+gen pass_replacement_payroll = (abs(payrollcost*100 - 0.6300319) < 0.01)
+drop expectedbenefit totalcost payrollcost
+gen mergeid = 1
+save "tests/test_params_replacement_output.dta", replace
+}
+
+/* Test maxbenefit */
+quietly {
+use parameters, clear
+replace replacementrate = 0.7
+replace maxbenefit = 1000
+save parameters, replace
+quietly do "run_anyassumptions.do"
+gen pass_maxben_expben = (abs(expectedbenefit - 399.59793) < 0.01)
+gen pass_maxben_total = (abs(totalcost/10^9 - 63.641178) < 0.01)
+gen pass_maxben_payroll = (abs(payrollcost*100 - 0.73642181) < 0.01)
+drop expectedbenefit totalcost payrollcost
+gen mergeid = 1
+save "tests/test_params_maxben_output.dta", replace
+}
+
+/* Test waiting_period */
+quietly {
+use parameters, clear
+replace maxbenefit = 600
+replace waiting_period = 5
+save parameters, replace
+quietly do "run_anyassumptions.do"
+gen pass_waiting_expben = (abs(expectedbenefit - 264.39389) < 0.01)
+gen pass_waiting_total = (abs(totalcost/10^9 - 42.10817) < 0.01)
+gen pass_waiting_payroll = (abs(payrollcost*100 - 0.48725335) < 0.01)
+drop expectedbenefit totalcost payrollcost
+gen mergeid = 1
+save "tests/test_params_waiting_output.dta", replace
+}
+
+/* Test work_requirement */
+quietly {
+use parameters, clear
+replace waiting_period = 0
+replace work_requirement = 1000
+save parameters, replace
+quietly do "run_anyassumptions.do"
+gen pass_workhrs_expben = (abs(expectedbenefit - 297.452) < 0.01)
+gen pass_workhrs_total = (abs(totalcost/10^9 - 47.373103) < 0.01)
+gen pass_workhrs_payroll = (abs(payrollcost*100 - .54817633) < 0.01)
+drop expectedbenefit totalcost payrollcost
+gen mergeid = 1
+save "tests/test_params_workhrs_output.dta", replace
+}
+
+/* Test include_ownhealth */
+quietly {
+use parameters, clear
+replace work_requirement = 0
+replace include_ownhealth = 0
+save parameters, replace
+quietly do "run_anyassumptions.do"
+gen pass_ownhealth_expben = (abs(expectedbenefit - 127.06824) < 0.01)
+gen pass_ownhealth_total = (abs(totalcost/10^9 - 20.237271) < 0.01)
+gen pass_ownhealth_payroll = (abs(payrollcost*100 - .23417494) < 0.01)
+drop expectedbenefit totalcost payrollcost
+gen mergeid = 1
+save "tests/test_params_ownhealth_output.dta", replace
+}
+
+/* Test include_childhealth */
+quietly {
+use parameters, clear
+replace include_ownhealth = 1
+replace include_childhealth = 0
+save parameters, replace
+quietly do "run_anyassumptions.do"
+gen pass_childhealth_expben = (abs(expectedbenefit - 305.9642) < 0.01)
+gen pass_childhealth_total = (abs(totalcost/10^9 - 48.728785) < 0.01)
+gen pass_childhealth_payroll = (abs(payrollcost*100 - .56386353) < 0.01)
+drop expectedbenefit totalcost payrollcost
+gen mergeid = 1
+save "tests/test_params_childhealth_output.dta", replace
+}
+
+/* Test include_spousehealth */
+quietly {
+use parameters, clear
+replace include_childhealth = 1
+replace include_spousehealth = 0
+save parameters, replace
+quietly do "run_anyassumptions.do"
+gen pass_spousehealth_expben = (abs(expectedbenefit - 298.06427) < 0.01)
+gen pass_spousehealth_total = (abs(totalcost/10^9 - 47.470617) < 0.01)
+gen pass_spousehealth_payroll = (abs(payrollcost*100 - .54930467) < 0.01)
+drop expectedbenefit totalcost payrollcost
+gen mergeid = 1
+save "tests/test_params_spousehealth_output.dta", replace
+}
+
+/* Test include_parenthealth */
+quietly {
+use parameters, clear
+replace include_spousehealth = 1
+replace include_parenthealth = 0
+save parameters, replace
+quietly do "run_anyassumptions.do"
+gen pass_parenthealth_expben = (abs(expectedbenefit - 297.14026) < 0.01)
+gen pass_parenthealth_total = (abs(totalcost/10^9 - 47.323455) < 0.01)
+gen pass_parenthealth_payroll = (abs(payrollcost*100 - .54760179) < 0.01)
+drop expectedbenefit totalcost payrollcost
+gen mergeid = 1
+save "tests/test_params_parenthealth_output.dta", replace
+}
+
+/* Test include_otherrealhealth */
+quietly {
+use parameters, clear
+replace include_parenthealth = 1
+replace include_otherrelhealth = 0
+save parameters, replace
+quietly do "run_anyassumptions.do"
+gen pass_otherrel_expben = (abs(expectedbenefit - 309.1489) < 0.01)
+gen pass_otherrel_total = (abs(totalcost/10^9 - 49.235988) < 0.01)
+gen pass_otherrel_payroll = (abs(payrollcost*100 - .56973263) < 0.01)
+drop expectedbenefit totalcost payrollcost
+gen mergeid = 1
+save "tests/test_params_otherrel_output.dta", replace
+}
+
+/* Test include_military */
+quietly {
+use parameters, clear
+replace include_otherrelhealth = 1
+replace include_military = 0
+save parameters, replace
+quietly do "run_anyassumptions.do"
+gen pass_military_expben = (abs(expectedbenefit - 308.70319) < 0.01)
+gen pass_military_total = (abs(totalcost/10^9 - 49.165005) < 0.01)
+gen pass_military_payroll = (abs(payrollcost*100 - .56891125) < 0.01)
+drop expectedbenefit totalcost payrollcost
+gen mergeid = 1
+save "tests/test_params_military_output.dta", replace
+}
+
+/* Test include_otherreason */
+quietly {
+use parameters, clear
+replace include_military = 1
+replace include_otherreason = 0
+save parameters, replace
+quietly do "run_anyassumptions.do"
+gen pass_other_expben = (abs(expectedbenefit - 312.18195) < 0.01)
+gen pass_other_total = (abs(totalcost/10^9 - 49.719038) < 0.01)
+gen pass_other_payroll = (abs(payrollcost*100 - .57532224) < 0.01)
+drop expectedbenefit totalcost payrollcost
+gen mergeid = 1
+save "tests/test_params_other_output.dta", replace
+}
+
+/* Test include_newchild */
+quietly {
+use parameters, clear
+replace include_otherreason = 1
+replace include_newchild = 0
+save parameters, replace
+quietly do "run_anyassumptions.do"
+gen pass_newchild_expben = (abs(expectedbenefit - 233.6673) < 0.01)
+gen pass_newchild_total = (abs(totalcost/10^9 - 37.21456) < 0.01)
+gen pass_newchild_payroll = (abs(payrollcost*100 - .43062707) < 0.01)
+drop expectedbenefit totalcost payrollcost
+gen mergeid = 1
+save "tests/test_params_newchild_output.dta", replace
+}
+
+/* Check that all tests pass, or which fail */
+quietly{
+use "tests/test_params_basecase_output.dta", clear
+gen pass_basecase = pass_basecase_expben * pass_basecase_total * pass_basecase_payroll
+if pass_basecase==1 {
+noisily di "Base case passes"
+}
+else {
+noisily di "Base case fails"
+noisily sum pass_basecase_expben pass_basecase_total pass_basecase_payroll
+}
+merge 1:1 mergeid using "tests/test_params_duration_output.dta", nogen norep
+gen pass_duration = pass_duration_expben * pass_duration_total * pass_duration_payroll
+if pass_duration == 1 {
+noisily di "Duration parameter passes"
+}
+else {
+noisily di "Duration parameter fails"
+noisily sum pass_duration_expben pass_duration_total pass_duration_payroll
+}
+merge 1:1 mergeid using "tests/test_params_replacement_output.dta", nogen norep
+gen pass_replacement = pass_replacement_expben * pass_replacement_total * pass_replacement_payroll
+if pass_replacement == 1 {
+noisily di "Replacement rate parameter passes"
+}
+else {
+noisily di "Replacement rate parameter fails"
+noisily sum pass_replacement_expben pass_replacement_total pass_replacement_payroll
+}
+merge 1:1 mergeid using "tests/test_params_maxben_output.dta", nogen norep
+gen pass_maxben = pass_maxben_expben * pass_maxben_total * pass_maxben_payroll
+if pass_maxben == 1 {
+noisily di "Maximum benefit parameter passes"
+}
+else {
+noisily di "Maximum benefit parameter fails"
+noisily sum pass_maxben_expben pass_maxben_total pass_maxben_payroll
+}
+merge 1:1 mergeid using "tests/test_params_waiting_output.dta", nogen norep
+gen pass_waiting = pass_waiting_expben * pass_waiting_total * pass_waiting_payroll
+if pass_waiting == 1 {
+noisily di "Waiting period parameter passes"
+}
+else {
+noisily di "Waiting period parameter fails"
+noisily sum pass_waiting_expben pass_waiting_total pass_waiting_payroll
+}
+merge 1:1 mergeid using "tests/test_params_workhrs_output.dta", nogen norep
+gen pass_workhrs = pass_workhrs_expben * pass_workhrs_total * pass_workhrs_payroll
+if pass_workhrs == 1 {
+noisily di "Work hours requirement parameter passes"
+}
+else {
+noisily di "Work hours requirement parameter fails"
+noisily sum pass_workhrs_expben pass_workhrs_total pass_workhrs_payroll
+}
+merge 1:1 mergeid using "tests/test_params_ownhealth_output.dta", nogen norep
+gen pass_ownhealth = pass_ownhealth_expben * pass_ownhealth_total * pass_ownhealth_payroll
+if pass_ownhealth == 1 {
+noisily di "Include ownh health parameter passes"
+}
+else {
+noisily di "Include own health parameter fails"
+noisily sum pass_ownhealth_expben pass_ownhealth_total pass_ownhealth_payroll
+}
+merge 1:1 mergeid using "tests/test_params_childhealth_output.dta", nogen norep
+gen pass_childhealth = pass_childhealth_expben * pass_childhealth_total * pass_childhealth_payroll
+if pass_childhealth == 1 {
+noisily di "Include child health parameter passes"
+}
+else {
+noisily di "Include child health parameter fails"
+noisily sum pass_childhealth_expben pass_childhealth_total pass_childhealth_payroll
+}
+merge 1:1 mergeid using "tests/test_params_spousehealth_output.dta", nogen norep
+gen pass_spousehealth = pass_spousehealth_expben * pass_spousehealth_total * pass_spousehealth_payroll
+if pass_spousehealth == 1 {
+noisily di "Include spouse health parameter passes"
+}
+else {
+noisily di "Include spouse health parameter fails"
+noisily sum pass_spousehealth_expben pass_spousehealth_total pass_spousehealth_payroll
+}
+merge 1:1 mergeid using "tests/test_params_parenthealth_output.dta", nogen norep
+gen pass_parenthealth = pass_parenthealth_expben * pass_parenthealth_total * pass_parenthealth_payroll
+if pass_parenthealth == 1 {
+noisily di "Include parent health parameter passes"
+}
+else {
+noisily di "Include parent health parameter fails"
+noisily sum pass_parenthealth_expben pass_parenthealth_total pass_parenthealth_payroll
+}
+merge 1:1 mergeid using "tests/test_params_otherrel_output.dta", nogen norep
+gen pass_otherrel = pass_otherrel_expben * pass_otherrel_total * pass_otherrel_payroll
+if pass_otherrel == 1 {
+noisily di "Include other relative health parameter passes"
+}
+else {
+noisily di "Include other relative health parameter fails"
+noisily sum pass_otherrel_expben pass_otherrel_total pass_otherrel_payroll
+}
+merge 1:1 mergeid using "tests/test_params_military_output.dta", nogen norep
+gen pass_military = pass_military_expben * pass_military_total * pass_military_payroll
+if pass_military == 1 {
+noisily di "Include military parameter passes"
+}
+else {
+noisily di "Include military parameter fails"
+noisily sum pass_military_expben pass_military_total pass_military_payroll
+}
+merge 1:1 mergeid using "tests/test_params_other_output.dta", nogen norep
+gen pass_other = pass_other_expben * pass_other_total * pass_other_payroll
+if pass_other == 1 {
+noisily di "Include other reason parameter passes"
+}
+else {
+noisily di "Include other reason parameter fails"
+noisily sum pass_other_expben pass_other_total pass_other_payroll
+}
+merge 1:1 mergeid using "tests/test_params_newchild_output.dta", nogen norep
+gen pass_newchild = pass_newchild_expben * pass_newchild_total * pass_newchild_payroll
+if pass_newchild == 1 {
+noisily di "Include new child parameter passes"
+}
+else {
+noisily di "Include new child parameter fails"
+noisily sum pass_newchild_expben pass_newchild_total pass_newchild_payroll
+}
+}
+
+


### PR DESCRIPTION
This PR adds a pair of do-files that test the parameters and the assumptions. Both testing files start with a base case. They then change one parameter (or assumption) and check the results, then reset the parameter (or assumption) and test the next one. 

This PR does not change any other files. I expect to merge this in shortly. 