### PR TITLE
Further fixes

### DIFF
--- a/tests/test_assumptions.do
+++ b/tests/test_assumptions.do
@@ -191,9 +191,9 @@ replace reduce_newchild = 1.0
 replace frac_employerpush = 0.4
 save assumptions, replace
 do "run_anyassumptions.do"
-gen pass_emppush_expben = (abs(expectedbenefit - 216.7027) < 0.01)
-gen pass_emppush_total = (abs(totalcost/10^9 - 34.512732) < 0.01)
-gen pass_emppush_payroll = (abs(payrollcost*100 - .39936295) < 0.01)
+gen pass_emppush_expben = (abs(expectedbenefit - 247.8717) < 0.01)
+gen pass_emppush_total = (abs(totalcost/10^9 - 39.476793) < 0.01)
+gen pass_emppush_payroll = (abs(payrollcost*100 - .45680446) < 0.01)
 drop expectedbenefit totalcost payrollcost
 gen mergeid = 1
 save "tests/test_assum_emppush_output.dta", replace


### PR DESCRIPTION
This PR makes 3 changes. The first is the addition of `fast` options to the collapse statements for the FMLA results. This reduces the model runtime by approximately 20 percent. 

The second is a minor change to the calculation of `fourweekshigh`. The new calculation makes this determination independent of the maximum duration. This is instead a correction to the problem that the model would produce an error if the maximum leave duration was set too low (below 20 days). The new setup does not change the results if the duration is set over 20 days, but it eliminates the error (and allows the model to run) for a low maximum duration. 

Finally, this makes a correction to the calculation of the duration for those subject to the partial employer push. The previous setup used the wrong duration measure, namely that it had already capped leave duration at `maxduration_days`, and so capping it at `maxduration_days+20` was not binding even though it should have been. This change definitely affects results if the `frac_employerpush` parameter is less than 1. The effect is to increase the cost somewhat. For the AEI-Brookings proposal, this increases the cost under the partial employer push option by approximately $5 billion (from $34.5b to $39.5b), a nonnegligible change. 

@begitis, would you mind reviewing the last change described here?