### PR TITLE
Parameter inputs

### DIFF
--- a/documentation/policy_parameters.md
+++ b/documentation/policy_parameters.md
@@ -4,7 +4,7 @@
 `maxduration_days`
  - Definition: Maximum duration of days receiving paid leave benefits, annual basis
  - Limitations:
-   - Minimum: parameter value must exceed 0 (strict requirement)
+   - Minimum: parameter value should be nonnegative (strict requirement)
    - Maximum: parameter value should not exceed 121 days (recommendation)
 
 `waiting_period`
@@ -12,17 +12,20 @@
  - Limitations:
    - Minimum: parameter value should be nonnegative (recommendation)
    - Maximum: parameter value should not exceed 20 days (recommendation)
+ - Note: A negative value should be interpreted as allowing leave before the life event occurs.
 
 ## Payment parameters
 `replacementrate`
  - Definition: Proportion of usual wages paid during leave, weekly basis while on program
  - Limitations:
-   - Minimum: parameter value should not be negative (recommendation)
+   - Minimum: parameter value should be nonnegative (recommendation)
+ - Note: A negative value should be interpreted as a surtax on lost income. 
 
 `maxbenefit`
  - Definition: Maximum weekly benefit amount
  - Limitations:
-   - Mimumum: parameter value should not be negative (recommendation)
+   - Mimumum: parameter value should be nonnegative (recommendation)
+ - Note: A negative value should be interpreted as a minimum surtax on lost income.
 
 ## Eligibility requirements
 `work_requirement`
@@ -33,32 +36,32 @@
 ## Types of leave included
 `include_ownhealth`
  - Definition: Whether paid leave program includes own medical leave (1 for yes, 0 for no)
- - Limitations: possible values of 0 or 1
+ - Limitations: possible values of 0 or 1 (strict requirement)
 
 `include_childhealth`
  - Definition: Whether paid leave program includes leave to care for one's ill child (1 for yes, 0 for no)
- - Limitations: possible values of 0 or 1
+ - Limitations: possible values of 0 or 1 (strict requirement)
 
 `include_spousehealth`
  - Definition: Whether paid leave program includes leave to care for one's ill spouse (1 for yes, 0 for no)
- - Limitations: possible values of 0 or 1
+ - Limitations: possible values of 0 or 1 (strict requirement)
 
 `include_parenthealth`
  - Definition: Whether paid leave program includes leave to care for one's ill parent (1 for yes, 0 for no)
- - Limitations: possible values of 0 or 1
+ - Limitations: possible values of 0 or 1 (strict requirement)
 
 `include_otherrelhealth`
  - Definition: Whether paid leave program includes leave to care for a relative besides child, spouse or parent (1 for yes, 0 for no)
- - Limitations: possible values of 0 or 1
+ - Limitations: possible values of 0 or 1 (strict requirement)
 
 `include_military`
  - Definition: Whether paid leave program includes leave to address issues from deployment of a military member (1 for yes, 0 for no)
- - Limitations: possible values of 0 or 1
+ - Limitations: possible values of 0 or 1 (strict requirement)
 
 `include_otherreason`
  - Definition: Whether paid leave program includes leave for other reasons (1 for yes, 0 for no)
- - Limitations: possible values of 0 or 1
+ - Limitations: possible values of 0 or 1 (strict requirement)
 
 `include_newchild`
  - Definition: Whether paid leave program includes parental leave (1 for yes, 0 for no)
- - Limitations: possible values of 0 or 1
+ - Limitations: possible values of 0 or 1 (strict requirement)

--- a/documentation/takeup_assumptions.md
+++ b/documentation/takeup_assumptions.md
@@ -6,8 +6,9 @@
  - Recommended value: 0.159
    - Source: Fraction of employees who took leave the last 12 months, among FMLA eligible and covered employees, from [Klerman, Daley and Pozniak, (2012)](https://www.dol.gov/asp/evaluation/fmla/FMLA-2012-Technical-Report.pdf).
  - Limitations:
-   - Minimum: 0
-   - Maximum: 1
+   - Minimum: 0 (strict requirement)
+   - Maximum: 1 (recommendation)
+ - Note: A value greater than 1 should be interpreted as every eligible person taking paid leave at least once per year.
 
 ## Reduced take-up assumptions
 These parameters reduce the take-up rates for different types of leave. The parametes apply to each type of leave:
@@ -43,8 +44,9 @@ Recommended values:
 For a description of these and a comparison, see Gitis, Glynn and Hayes (2018) (forthcoming).
 
 Limitations: 
- - Minimum: 0
- - Maximum: 1
+ - Minimum: 0 (strict requirement)
+ - Maximum: 1 (recommendation)
+Note: A value greater than 1 should be interpreted as fraudulent use of the program.
 
 ## Employer push assumptions
 This parameter how employers respond to the creation of a paid leave program. 
@@ -60,5 +62,5 @@ This parameter how employers respond to the creation of a paid leave program.
    - Reduced employer push: `frac_employerpush = 0.4`
    - For a description of these and a comparison, see Gitis, Glynn and Hayes (2018) (forthcoming)
  - Limitations:
-   - Minimum: 0
-   - Maximum: 1
+   - Minimum: 0 (strict requirement)
+   - Maximum: 1 (strict requirement)

--- a/run_anyassumptions.do
+++ b/run_anyassumptions.do
@@ -1,4 +1,52 @@
 ****************************
+***     Check inputs     ***
+****************************
+// Check parameter inputs for unallowable values
+use parameters, clear
+assert maxduration_days >= 0
+assert include_ownhealth==0 | include_ownhealth==1
+assert include_childhealth==0 | include_childhealth==1
+assert include_spousehealth==0 | include_spousehealth==1
+assert include_parenthealth==0 | include_parenthealth==1
+assert include_otherrelhealth==0 | include_otherrelhealth==1
+assert include_military==0 | include_military==1
+assert include_otherreason==0 | include_otherreason==1
+assert include_newchild==0 | include_newchild==1
+// Check parameter inputs for problematic values
+if maxduration_days > 121 {
+  noisily di as err "Warning: High value for maxduration_days"
+}
+if waiting_period > 20 {
+  noisily di as err "Warning: High value for waiting_period"
+}
+if replacementrate < 0 {
+  noisily di as err "Warning: Negative value for replacementrate"
+}
+if maxbenefit < 0 {
+  noisily di as err "Warning: Negative value for maxbenefit"
+}
+if work_requirement < 0 {
+  noisily di as err "Warning: Negative value for work requirement"
+}
+// Check assumption inputs for unallowable values
+use assumptions, clear
+assert overall_takeup >= 0
+assert reduce_ownhealth >= 0
+assert reduce_childhealth >= 0
+assert reduce_spousehealth >= 0
+assert reduce_parenthealth >= 0
+assert reduce_otherrelhealth >= 0
+assert reduce_military >= 0
+assert reduce_otherreason >= 0
+assert reduce_newchild >= 0
+assert frac_employerpush >= 0 | frac_employerpush <= 1
+// Check assumption inputs for problematic values
+if overall_takeup > 1 {
+  noisily di as err "Warning: High value for take-up rate"
+}
+
+
+****************************
 *** FMLA Survey Analysis ***
 ****************************
 // Determine eligibility for paid leave, assuming FMLA eligibility rules
@@ -186,9 +234,11 @@ use "intermediate_files/takeupshares.dta", clear
 merge 1:1 leaveid using "intermediate_files/fracpaid.dta", nogen
 merge 1:1 leaveid using "intermediate_files/fracunder4_paid.dta", nogen
 merge 1:1 leaveid using "intermediate_files/daysunpaid.dta", nogen
+merge 1:1 leaveid using "intermediate_files/daysover.dta", nogen
 // Replace missing duration with zero
 replace daysunpaid = 0 if daysunpaid==.
-merge 1:1 leaveid using "intermediate_files/daysover.dta", nogen
+replace dayspaid = 0 if dayspaid==.
+replace daysover = 0 if daysover==.
 
 /* Merge in assumptions */
 gen mergeid = 1

--- a/tests/test_assumptions.do
+++ b/tests/test_assumptions.do
@@ -47,7 +47,7 @@ gen pass_basecase_total = (abs(totalcost/10^9 - 49.870676) < 0.01)
 gen pass_basecase_payroll = (abs(payrollcost*100 - 0.5770769) < 0.01)
 drop expectedbenefit totalcost payrollcost
 gen mergeid = 1
-save "tests/test_assum_basecase_output.dta", replace
+save "tests/test_output/test_assum_basecase_output.dta", replace
 }
 
 /* Test overall_takeup */
@@ -61,7 +61,7 @@ gen pass_takeup_total = (abs(totalcost/10^9 - 62.730408) < 0.01)
 gen pass_takeup_payroll = (abs(payrollcost*100 - 0.72588287) < 0.01)
 drop expectedbenefit totalcost payrollcost
 gen mergeid = 1
-save "tests/test_assum_takeup_output.dta", replace
+save "tests/test_output/test_assum_takeup_output.dta", replace
 }
 
 /* Test reduce_ownhealth */
@@ -76,7 +76,7 @@ gen pass_redmedical_total = (abs(totalcost/10^9 - 35.053978) < 0.01)
 gen pass_redmedical_payroll = (abs(payrollcost*100 - .40562595) < 0.01)
 drop expectedbenefit totalcost payrollcost
 gen mergeid = 1
-save "tests/test_assum_redmedical_output.dta", replace
+save "tests/test_output/test_assum_redmedical_output.dta", replace
 }
 
 /* Test reduce_childhealth */
@@ -91,7 +91,7 @@ gen pass_redchildh_total = (abs(totalcost/10^9 - 48.957166) < 0.01)
 gen pass_redchildh_payroll = (abs(payrollcost*100 - .56650625) < 0.01)
 drop expectedbenefit totalcost payrollcost
 gen mergeid = 1
-save "tests/test_assum_redchildh_output.dta", replace
+save "tests/test_output/test_assum_redchildh_output.dta", replace
 }
 
 /* Test reduce_spousehealth */
@@ -106,7 +106,7 @@ gen pass_redspouse_total = (abs(totalcost/10^9 - 47.950623) < 0.01)
 gen pass_redspouse_payroll = (abs(payrollcost*100 - .55485908) < 0.01)
 drop expectedbenefit totalcost payrollcost
 gen mergeid = 1
-save "tests/test_assum_redspouse_output.dta", replace
+save "tests/test_output/test_assum_redspouse_output.dta", replace
 }
 
 /* Test reduce_parenthealth */
@@ -121,7 +121,7 @@ gen pass_redparent_total = (abs(totalcost/10^9 - 47.578178) < 0.01)
 gen pass_redparent_payroll = (abs(payrollcost*100 - .55054934) < 0.01)
 drop expectedbenefit totalcost payrollcost
 gen mergeid = 1
-save "tests/test_assum_redparent_output.dta", replace
+save "tests/test_output/test_assum_redparent_output.dta", replace
 }
 
 /* Test reduce_otherrelhealth */
@@ -136,7 +136,7 @@ gen pass_redotherrel_total = (abs(totalcost/10^9 - 49.29946) < 0.01)
 gen pass_redotherrel_payroll = (abs(payrollcost*100 - .57046711) < 0.01)
 drop expectedbenefit totalcost payrollcost
 gen mergeid = 1
-save "tests/test_assum_redotherrel_output.dta", replace
+save "tests/test_output/test_assum_redotherrel_output.dta", replace
 }
 
 /* Test reduce_military */
@@ -151,7 +151,7 @@ gen pass_redmilitary_total = (abs(totalcost/10^9 - 49.80011) < 0.01)
 gen pass_redmilitary_payroll = (abs(payrollcost*100 - .57626031) < 0.01)
 drop expectedbenefit totalcost payrollcost
 gen mergeid = 1
-save "tests/test_assum_redmilitary_output.dta", replace
+save "tests/test_output/test_assum_redmilitary_output.dta", replace
 }
 
 /* Test reduce_otherreason */
@@ -166,7 +166,7 @@ gen pass_redother_total = (abs(totalcost/10^9 - 49.719038) < 0.01)
 gen pass_redother_payroll = (abs(payrollcost*100 - .57532224) < 0.01)
 drop expectedbenefit totalcost payrollcost
 gen mergeid = 1
-save "tests/test_assum_redother_output.dta", replace
+save "tests/test_output/test_assum_redother_output.dta", replace
 }
 
 /* Test reduce_newchild */
@@ -181,7 +181,7 @@ gen pass_rednewchild_total = (abs(totalcost/10^9 - 48.605061) < 0.01)
 gen pass_rednewchild_payroll = (abs(payrollcost*100 - .5624319) < 0.01)
 drop expectedbenefit totalcost payrollcost
 gen mergeid = 1
-save "tests/test_assum_rednewchild_output.dta", replace
+save "tests/test_output/test_assum_rednewchild_output.dta", replace
 }
 
 /* Test frac_employerpush */
@@ -196,12 +196,12 @@ gen pass_emppush_total = (abs(totalcost/10^9 - 39.476793) < 0.01)
 gen pass_emppush_payroll = (abs(payrollcost*100 - .45680446) < 0.01)
 drop expectedbenefit totalcost payrollcost
 gen mergeid = 1
-save "tests/test_assum_emppush_output.dta", replace
+save "tests/test_output/test_assum_emppush_output.dta", replace
 }
 
 /* Check that all tests pass, or which fail */
 quietly{
-use "tests/test_assum_basecase_output.dta", clear
+use "tests/test_output/test_assum_basecase_output.dta", clear
 gen pass_basecase = pass_basecase_expben * pass_basecase_total * pass_basecase_payroll
 if pass_basecase==1 {
 noisily di "Base case passes"
@@ -210,7 +210,7 @@ else {
 noisily di "Base case fails"
 noisily sum pass_basecase_expben pass_basecase_total pass_basecase_payroll
 }
-merge 1:1 mergeid using "tests/test_assum_takeup_output.dta", nogen norep
+merge 1:1 mergeid using "tests/test_output/test_assum_takeup_output.dta", nogen norep
 gen pass_takeup = pass_takeup_expben * pass_takeup_total * pass_takeup_payroll
 if pass_takeup == 1 {
 noisily di "Overall take-up assumption passes"
@@ -219,7 +219,7 @@ else {
 noisily di "Overall take-up assumption fails"
 noisily sum pass_takeup_expben pass_takeup_total pass_takeup_payroll
 }
-merge 1:1 mergeid using "tests/test_assum_redmedical_output.dta", nogen norep
+merge 1:1 mergeid using "tests/test_output/test_assum_redmedical_output.dta", nogen norep
 gen pass_redmedical = pass_redmedical_expben * pass_redmedical_total * pass_redmedical_payroll
 if pass_redmedical == 1 {
 noisily di "Reduce take-up for ownhealth assumption passes"
@@ -228,7 +228,7 @@ else {
 noisily di "Reduce take-up for ownhealth assumption fails"
 noisily sum pass_redmedical_expben pass_redmedical_total pass_redmedical_payroll
 }
-merge 1:1 mergeid using "tests/test_assum_redchildh_output.dta", nogen norep
+merge 1:1 mergeid using "tests/test_output/test_assum_redchildh_output.dta", nogen norep
 gen pass_redchildh = pass_redchildh_expben * pass_redchildh_total * pass_redchildh_payroll
 if pass_redchildh == 1 {
 noisily di "Reduce take-up for child health assumption passes"
@@ -237,7 +237,7 @@ else {
 noisily di "Reduce take-up for child health assumption fails"
 noisily sum pass_redchildh_expben pass_redchildh_total pass_redchildh_payroll
 }
-merge 1:1 mergeid using "tests/test_assum_redspouse_output.dta", nogen norep
+merge 1:1 mergeid using "tests/test_output/test_assum_redspouse_output.dta", nogen norep
 gen pass_redspouse = pass_redspouse_expben * pass_redspouse_total * pass_redspouse_payroll
 if pass_redspouse == 1 {
 noisily di "Reduce take-up for spouse health assumption passes"
@@ -246,7 +246,7 @@ else {
 noisily di "Reduce take-up for spouse health assumption fails"
 noisily sum pass_redspouse_expben pass_redspouse_total pass_redspouse_payroll
 }
-merge 1:1 mergeid using "tests/test_assum_redparent_output.dta", nogen norep
+merge 1:1 mergeid using "tests/test_output/test_assum_redparent_output.dta", nogen norep
 gen pass_redparent = pass_redparent_expben * pass_redparent_total * pass_redparent_payroll
 if pass_redparent == 1 {
 noisily di "Reduce take-up for parent health assumption passes"
@@ -255,7 +255,7 @@ else {
 noisily di "Reduce take-up for parent health assumption fails"
 noisily sum pass_redparent_expben pass_redparent_total pass_redparent_payroll
 }
-merge 1:1 mergeid using "tests/test_assum_redotherrel_output.dta", nogen norep
+merge 1:1 mergeid using "tests/test_output/test_assum_redotherrel_output.dta", nogen norep
 gen pass_redotherrel = pass_redotherrel_expben * pass_redotherrel_total * pass_redotherrel_payroll
 if pass_redotherrel == 1 {
 noisily di "Reduce take-up for other relative health assumption passes"
@@ -264,7 +264,7 @@ else {
 noisily di "Reduce take-up for other relative health assumption fails"
 noisily sum pass_redotherrel_expben pass_redotherrel_total pass_redotherrel_payroll
 }
-merge 1:1 mergeid using "tests/test_assum_redmilitary_output.dta", nogen norep
+merge 1:1 mergeid using "tests/test_output/test_assum_redmilitary_output.dta", nogen norep
 gen pass_redmilitary = pass_redmilitary_expben * pass_redmilitary_total * pass_redmilitary_payroll
 if pass_redmilitary == 1 {
 noisily di "Reduce take-up for military assumption passes"
@@ -273,7 +273,7 @@ else {
 noisily di "Reduce take-up for military assumption fails"
 noisily sum pass_redmilitary_expben pass_redmilitary_total pass_redmilitary_payroll
 }
-merge 1:1 mergeid using "tests/test_assum_redother_output.dta", nogen norep
+merge 1:1 mergeid using "tests/test_output/test_assum_redother_output.dta", nogen norep
 gen pass_redother = pass_redother_expben * pass_redother_total * pass_redother_payroll
 if pass_redother == 1 {
 noisily di "Reduce take-up for other reason assumption passes"
@@ -282,7 +282,7 @@ else {
 noisily di "Reduce take-up for other reason assumption fails"
 noisily sum pass_redother_expben pass_redother_total pass_redother_payroll
 }
-merge 1:1 mergeid using "tests/test_assum_rednewchild_output.dta", nogen norep
+merge 1:1 mergeid using "tests/test_output/test_assum_rednewchild_output.dta", nogen norep
 gen pass_rednewchild = pass_rednewchild_expben * pass_rednewchild_total * pass_rednewchild_payroll
 if pass_rednewchild == 1 {
 noisily di "Reduce take-up for new child assumption passes"
@@ -291,7 +291,7 @@ else {
 noisily di "Reduce take-up for new child assumption fails"
 noisily sum pass_rednewchild_expben pass_rednewchild_total pass_rednewchild_payroll
 }
-merge 1:1 mergeid using "tests/test_assum_emppush_output.dta", nogen norep
+merge 1:1 mergeid using "tests/test_output/test_assum_emppush_output.dta", nogen norep
 gen pass_emppush = pass_emppush_expben * pass_emppush_total * pass_emppush_payroll
 if pass_emppush == 1 {
 noisily di "Reduced employer push assumption passes"

--- a/tests/test_output/.gitignore
+++ b/tests/test_output/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/test_parameters.do
+++ b/tests/test_parameters.do
@@ -48,7 +48,7 @@ gen pass_basecase_total = (abs(totalcost/10^9 - 49.870676) < 0.01)
 gen pass_basecase_payroll = (abs(payrollcost*100 - 0.5770769) < 0.01)
 drop expectedbenefit totalcost payrollcost
 gen mergeid = 1
-save "tests/test_params_basecase_output.dta", replace
+save "tests/test_output/test_params_basecase_output.dta", replace
 }
 
 /* Test maxduration_days */
@@ -62,7 +62,7 @@ gen pass_duration_total = (abs(totalcost/10^9 - 65.580061) < 0.01)
 gen pass_duration_payroll = (abs(payrollcost*100 - 0.75885751) < 0.01)
 drop expectedbenefit totalcost payrollcost
 gen mergeid = 1
-save "tests/test_params_duration_output.dta", replace
+save "tests/test_output/test_params_duration_output.dta", replace
 }
 
 /* Test replacementrate */
@@ -77,7 +77,7 @@ gen pass_replacement_total = (abs(totalcost/10^9 - 54.447018) < 0.01)
 gen pass_replacement_payroll = (abs(payrollcost*100 - 0.6300319) < 0.01)
 drop expectedbenefit totalcost payrollcost
 gen mergeid = 1
-save "tests/test_params_replacement_output.dta", replace
+save "tests/test_output/test_params_replacement_output.dta", replace
 }
 
 /* Test maxbenefit */
@@ -92,7 +92,7 @@ gen pass_maxben_total = (abs(totalcost/10^9 - 63.641178) < 0.01)
 gen pass_maxben_payroll = (abs(payrollcost*100 - 0.73642181) < 0.01)
 drop expectedbenefit totalcost payrollcost
 gen mergeid = 1
-save "tests/test_params_maxben_output.dta", replace
+save "tests/test_output/test_params_maxben_output.dta", replace
 }
 
 /* Test waiting_period */
@@ -107,7 +107,7 @@ gen pass_waiting_total = (abs(totalcost/10^9 - 42.10817) < 0.01)
 gen pass_waiting_payroll = (abs(payrollcost*100 - 0.48725335) < 0.01)
 drop expectedbenefit totalcost payrollcost
 gen mergeid = 1
-save "tests/test_params_waiting_output.dta", replace
+save "tests/test_output/test_params_waiting_output.dta", replace
 }
 
 /* Test work_requirement */
@@ -122,7 +122,7 @@ gen pass_workhrs_total = (abs(totalcost/10^9 - 47.373103) < 0.01)
 gen pass_workhrs_payroll = (abs(payrollcost*100 - .54817633) < 0.01)
 drop expectedbenefit totalcost payrollcost
 gen mergeid = 1
-save "tests/test_params_workhrs_output.dta", replace
+save "tests/test_output/test_params_workhrs_output.dta", replace
 }
 
 /* Test include_ownhealth */
@@ -137,7 +137,7 @@ gen pass_ownhealth_total = (abs(totalcost/10^9 - 20.237271) < 0.01)
 gen pass_ownhealth_payroll = (abs(payrollcost*100 - .23417494) < 0.01)
 drop expectedbenefit totalcost payrollcost
 gen mergeid = 1
-save "tests/test_params_ownhealth_output.dta", replace
+save "tests/test_output/test_params_ownhealth_output.dta", replace
 }
 
 /* Test include_childhealth */
@@ -152,7 +152,7 @@ gen pass_childhealth_total = (abs(totalcost/10^9 - 48.728785) < 0.01)
 gen pass_childhealth_payroll = (abs(payrollcost*100 - .56386353) < 0.01)
 drop expectedbenefit totalcost payrollcost
 gen mergeid = 1
-save "tests/test_params_childhealth_output.dta", replace
+save "tests/test_output/test_params_childhealth_output.dta", replace
 }
 
 /* Test include_spousehealth */
@@ -167,7 +167,7 @@ gen pass_spousehealth_total = (abs(totalcost/10^9 - 47.470617) < 0.01)
 gen pass_spousehealth_payroll = (abs(payrollcost*100 - .54930467) < 0.01)
 drop expectedbenefit totalcost payrollcost
 gen mergeid = 1
-save "tests/test_params_spousehealth_output.dta", replace
+save "tests/test_output/test_params_spousehealth_output.dta", replace
 }
 
 /* Test include_parenthealth */
@@ -182,7 +182,7 @@ gen pass_parenthealth_total = (abs(totalcost/10^9 - 47.323455) < 0.01)
 gen pass_parenthealth_payroll = (abs(payrollcost*100 - .54760179) < 0.01)
 drop expectedbenefit totalcost payrollcost
 gen mergeid = 1
-save "tests/test_params_parenthealth_output.dta", replace
+save "tests/test_output/test_params_parenthealth_output.dta", replace
 }
 
 /* Test include_otherrealhealth */
@@ -197,7 +197,7 @@ gen pass_otherrel_total = (abs(totalcost/10^9 - 49.235988) < 0.01)
 gen pass_otherrel_payroll = (abs(payrollcost*100 - .56973263) < 0.01)
 drop expectedbenefit totalcost payrollcost
 gen mergeid = 1
-save "tests/test_params_otherrel_output.dta", replace
+save "tests/test_output/test_params_otherrel_output.dta", replace
 }
 
 /* Test include_military */
@@ -212,7 +212,7 @@ gen pass_military_total = (abs(totalcost/10^9 - 49.165005) < 0.01)
 gen pass_military_payroll = (abs(payrollcost*100 - .56891125) < 0.01)
 drop expectedbenefit totalcost payrollcost
 gen mergeid = 1
-save "tests/test_params_military_output.dta", replace
+save "tests/test_output/test_params_military_output.dta", replace
 }
 
 /* Test include_otherreason */
@@ -227,7 +227,7 @@ gen pass_other_total = (abs(totalcost/10^9 - 49.719038) < 0.01)
 gen pass_other_payroll = (abs(payrollcost*100 - .57532224) < 0.01)
 drop expectedbenefit totalcost payrollcost
 gen mergeid = 1
-save "tests/test_params_other_output.dta", replace
+save "tests/test_output/test_params_other_output.dta", replace
 }
 
 /* Test include_newchild */
@@ -242,12 +242,12 @@ gen pass_newchild_total = (abs(totalcost/10^9 - 37.21456) < 0.01)
 gen pass_newchild_payroll = (abs(payrollcost*100 - .43062707) < 0.01)
 drop expectedbenefit totalcost payrollcost
 gen mergeid = 1
-save "tests/test_params_newchild_output.dta", replace
+save "tests/test_output/test_params_newchild_output.dta", replace
 }
 
 /* Check that all tests pass, or which fail */
 quietly{
-use "tests/test_params_basecase_output.dta", clear
+use "tests/test_output/test_params_basecase_output.dta", clear
 gen pass_basecase = pass_basecase_expben * pass_basecase_total * pass_basecase_payroll
 if pass_basecase==1 {
 noisily di "Base case passes"
@@ -256,7 +256,7 @@ else {
 noisily di "Base case fails"
 noisily sum pass_basecase_expben pass_basecase_total pass_basecase_payroll
 }
-merge 1:1 mergeid using "tests/test_params_duration_output.dta", nogen norep
+merge 1:1 mergeid using "tests/test_output/test_params_duration_output.dta", nogen norep
 gen pass_duration = pass_duration_expben * pass_duration_total * pass_duration_payroll
 if pass_duration == 1 {
 noisily di "Duration parameter passes"
@@ -265,7 +265,7 @@ else {
 noisily di "Duration parameter fails"
 noisily sum pass_duration_expben pass_duration_total pass_duration_payroll
 }
-merge 1:1 mergeid using "tests/test_params_replacement_output.dta", nogen norep
+merge 1:1 mergeid using "tests/test_output/test_params_replacement_output.dta", nogen norep
 gen pass_replacement = pass_replacement_expben * pass_replacement_total * pass_replacement_payroll
 if pass_replacement == 1 {
 noisily di "Replacement rate parameter passes"
@@ -274,7 +274,7 @@ else {
 noisily di "Replacement rate parameter fails"
 noisily sum pass_replacement_expben pass_replacement_total pass_replacement_payroll
 }
-merge 1:1 mergeid using "tests/test_params_maxben_output.dta", nogen norep
+merge 1:1 mergeid using "tests/test_output/test_params_maxben_output.dta", nogen norep
 gen pass_maxben = pass_maxben_expben * pass_maxben_total * pass_maxben_payroll
 if pass_maxben == 1 {
 noisily di "Maximum benefit parameter passes"
@@ -283,7 +283,7 @@ else {
 noisily di "Maximum benefit parameter fails"
 noisily sum pass_maxben_expben pass_maxben_total pass_maxben_payroll
 }
-merge 1:1 mergeid using "tests/test_params_waiting_output.dta", nogen norep
+merge 1:1 mergeid using "tests/test_output/test_params_waiting_output.dta", nogen norep
 gen pass_waiting = pass_waiting_expben * pass_waiting_total * pass_waiting_payroll
 if pass_waiting == 1 {
 noisily di "Waiting period parameter passes"
@@ -292,7 +292,7 @@ else {
 noisily di "Waiting period parameter fails"
 noisily sum pass_waiting_expben pass_waiting_total pass_waiting_payroll
 }
-merge 1:1 mergeid using "tests/test_params_workhrs_output.dta", nogen norep
+merge 1:1 mergeid using "tests/test_output/test_params_workhrs_output.dta", nogen norep
 gen pass_workhrs = pass_workhrs_expben * pass_workhrs_total * pass_workhrs_payroll
 if pass_workhrs == 1 {
 noisily di "Work hours requirement parameter passes"
@@ -301,7 +301,7 @@ else {
 noisily di "Work hours requirement parameter fails"
 noisily sum pass_workhrs_expben pass_workhrs_total pass_workhrs_payroll
 }
-merge 1:1 mergeid using "tests/test_params_ownhealth_output.dta", nogen norep
+merge 1:1 mergeid using "tests/test_output/test_params_ownhealth_output.dta", nogen norep
 gen pass_ownhealth = pass_ownhealth_expben * pass_ownhealth_total * pass_ownhealth_payroll
 if pass_ownhealth == 1 {
 noisily di "Include ownh health parameter passes"
@@ -310,7 +310,7 @@ else {
 noisily di "Include own health parameter fails"
 noisily sum pass_ownhealth_expben pass_ownhealth_total pass_ownhealth_payroll
 }
-merge 1:1 mergeid using "tests/test_params_childhealth_output.dta", nogen norep
+merge 1:1 mergeid using "tests/test_output/test_params_childhealth_output.dta", nogen norep
 gen pass_childhealth = pass_childhealth_expben * pass_childhealth_total * pass_childhealth_payroll
 if pass_childhealth == 1 {
 noisily di "Include child health parameter passes"
@@ -319,7 +319,7 @@ else {
 noisily di "Include child health parameter fails"
 noisily sum pass_childhealth_expben pass_childhealth_total pass_childhealth_payroll
 }
-merge 1:1 mergeid using "tests/test_params_spousehealth_output.dta", nogen norep
+merge 1:1 mergeid using "tests/test_output/test_params_spousehealth_output.dta", nogen norep
 gen pass_spousehealth = pass_spousehealth_expben * pass_spousehealth_total * pass_spousehealth_payroll
 if pass_spousehealth == 1 {
 noisily di "Include spouse health parameter passes"
@@ -328,7 +328,7 @@ else {
 noisily di "Include spouse health parameter fails"
 noisily sum pass_spousehealth_expben pass_spousehealth_total pass_spousehealth_payroll
 }
-merge 1:1 mergeid using "tests/test_params_parenthealth_output.dta", nogen norep
+merge 1:1 mergeid using "tests/test_output/test_params_parenthealth_output.dta", nogen norep
 gen pass_parenthealth = pass_parenthealth_expben * pass_parenthealth_total * pass_parenthealth_payroll
 if pass_parenthealth == 1 {
 noisily di "Include parent health parameter passes"
@@ -337,7 +337,7 @@ else {
 noisily di "Include parent health parameter fails"
 noisily sum pass_parenthealth_expben pass_parenthealth_total pass_parenthealth_payroll
 }
-merge 1:1 mergeid using "tests/test_params_otherrel_output.dta", nogen norep
+merge 1:1 mergeid using "tests/test_output/test_params_otherrel_output.dta", nogen norep
 gen pass_otherrel = pass_otherrel_expben * pass_otherrel_total * pass_otherrel_payroll
 if pass_otherrel == 1 {
 noisily di "Include other relative health parameter passes"
@@ -346,7 +346,7 @@ else {
 noisily di "Include other relative health parameter fails"
 noisily sum pass_otherrel_expben pass_otherrel_total pass_otherrel_payroll
 }
-merge 1:1 mergeid using "tests/test_params_military_output.dta", nogen norep
+merge 1:1 mergeid using "tests/test_output/test_params_military_output.dta", nogen norep
 gen pass_military = pass_military_expben * pass_military_total * pass_military_payroll
 if pass_military == 1 {
 noisily di "Include military parameter passes"
@@ -355,7 +355,7 @@ else {
 noisily di "Include military parameter fails"
 noisily sum pass_military_expben pass_military_total pass_military_payroll
 }
-merge 1:1 mergeid using "tests/test_params_other_output.dta", nogen norep
+merge 1:1 mergeid using "tests/test_output/test_params_other_output.dta", nogen norep
 gen pass_other = pass_other_expben * pass_other_total * pass_other_payroll
 if pass_other == 1 {
 noisily di "Include other reason parameter passes"
@@ -364,7 +364,7 @@ else {
 noisily di "Include other reason parameter fails"
 noisily sum pass_other_expben pass_other_total pass_other_payroll
 }
-merge 1:1 mergeid using "tests/test_params_newchild_output.dta", nogen norep
+merge 1:1 mergeid using "tests/test_output/test_params_newchild_output.dta", nogen norep
 gen pass_newchild = pass_newchild_expben * pass_newchild_total * pass_newchild_payroll
 if pass_newchild == 1 {
 noisily di "Include new child parameter passes"


### PR DESCRIPTION
This PR addresses the concerns I raised in issue #11. In that PR, I mentioned that certain values for maximum duration and waiting period would break the code, and that several were inadvisable. However, PR #16 made some changes to the `collapse` and duration calculation logic that eliminated the issue of the code breaking for the code-breaking input values. 

This PR makes two further changes. The first is to add a series of assertions at the beginning of the `run_anyassumptions.do` file to ensure that unallowable inputs are not used (negative durations, negative take-up, employer push below zero or above 1, etc.) and to provide warnings if problematic values are used (negative replacement rates, overly long waiting periods, etc.) that would not break the code but may produce nonsensical results. 

The other change is to move the output from the tests into a separate file with a `.gitignore` statement. This change is one of convenience. 

The changes in the PR do not affect the results or break backward compatibility. As such, I expect to merge this in shortly. 