### PR TITLE
Rewrite tests

### DIFF
--- a/tests/test_assumptions.do
+++ b/tests/test_assumptions.do
@@ -47,12 +47,8 @@ save assumptions, replace
 /* Test base case*/
 quietly {
 do "run_anyassumptions.do"
-gen pass_basecase_expben = (abs(expectedbenefit - 313.13403) < 0.01)
-gen pass_basecase_total = (abs(totalcost/10^9 - 49.870676) < 0.01)
-gen pass_basecase_payroll = (abs(payrollcost*100 - 0.5770769) < 0.01)
-drop expectedbenefit totalcost payrollcost
-gen mergeid = 1
-save "tests/test_output/test_assum_basecase_output.dta", replace
+gen testid = "base_case"
+save "tests/test_output/test_assum_output.dta", replace
 }
 
 /* Test overall_takeup */
@@ -61,12 +57,9 @@ use assumptions, clear
 replace overall_takeup = 0.2
 save assumptions, replace
 do "run_anyassumptions.do"
-gen pass_takeup_expben = (abs(expectedbenefit - 393.8793) < 0.01)
-gen pass_takeup_total = (abs(totalcost/10^9 - 62.730408) < 0.01)
-gen pass_takeup_payroll = (abs(payrollcost*100 - 0.72588287) < 0.01)
-drop expectedbenefit totalcost payrollcost
-gen mergeid = 1
-save "tests/test_output/test_assum_takeup_output.dta", replace
+gen testid = "overall_takeup"
+merge 1:1 testid using "tests/test_output/test_assum_output.dta", nogen
+save "tests/test_output/test_assum_output.dta", replace
 }
 
 /* Test reduce_ownhealth */
@@ -76,12 +69,9 @@ replace overall_takeup = 0.159
 replace reduce_ownhealth = 0.5
 save assumptions, replace
 do "run_anyassumptions.do"
-gen pass_redmedical_expben = (abs(expectedbenefit - 220.1012 ) < 0.01)
-gen pass_redmedical_total = (abs(totalcost/10^9 - 35.053978) < 0.01)
-gen pass_redmedical_payroll = (abs(payrollcost*100 - .40562595) < 0.01)
-drop expectedbenefit totalcost payrollcost
-gen mergeid = 1
-save "tests/test_output/test_assum_redmedical_output.dta", replace
+gen testid = "reduce_ownhealth"
+merge 1:1 testid using "tests/test_output/test_assum_output.dta", nogen
+save "tests/test_output/test_assum_output.dta", replace
 }
 
 /* Test reduce_childhealth */
@@ -91,12 +81,9 @@ replace reduce_ownhealth = 1.0
 replace reduce_childhealth = 0.2
 save assumptions, replace
 do "run_anyassumptions.do"
-gen pass_redchildh_expben = (abs(expectedbenefit - 307.3982  ) < 0.01)
-gen pass_redchildh_total = (abs(totalcost/10^9 - 48.957166) < 0.01)
-gen pass_redchildh_payroll = (abs(payrollcost*100 - .56650625) < 0.01)
-drop expectedbenefit totalcost payrollcost
-gen mergeid = 1
-save "tests/test_output/test_assum_redchildh_output.dta", replace
+gen testid = "reduce_childhealth"
+merge 1:1 testid using "tests/test_output/test_assum_output.dta", nogen
+save "tests/test_output/test_assum_output.dta", replace
 }
 
 /* Test reduce_spousehealth */
@@ -106,12 +93,9 @@ replace reduce_childhealth = 1.0
 replace reduce_spousehealth = 0.2
 save assumptions, replace
 do "run_anyassumptions.do"
-gen pass_redspouse_expben = (abs(expectedbenefit - 301.0782) < 0.01)
-gen pass_redspouse_total = (abs(totalcost/10^9 - 47.950623) < 0.01)
-gen pass_redspouse_payroll = (abs(payrollcost*100 - .55485908) < 0.01)
-drop expectedbenefit totalcost payrollcost
-gen mergeid = 1
-save "tests/test_output/test_assum_redspouse_output.dta", replace
+gen testid = "reduce_spousehealth"
+merge 1:1 testid using "tests/test_output/test_assum_output.dta", nogen
+save "tests/test_output/test_assum_output.dta", replace
 }
 
 /* Test reduce_parenthealth */
@@ -121,12 +105,9 @@ replace reduce_spousehealth = 1.0
 replace reduce_parenthealth = 0.1
 save assumptions, replace
 do "run_anyassumptions.do"
-gen pass_redparent_expben = (abs(expectedbenefit - 298.7396) < 0.01)
-gen pass_redparent_total = (abs(totalcost/10^9 - 47.578178) < 0.01)
-gen pass_redparent_payroll = (abs(payrollcost*100 - .55054934) < 0.01)
-drop expectedbenefit totalcost payrollcost
-gen mergeid = 1
-save "tests/test_output/test_assum_redparent_output.dta", replace
+gen testid = "reduce_parenthealth"
+merge 1:1 testid using "tests/test_output/test_assum_output.dta", nogen
+save "tests/test_output/test_assum_output.dta", replace
 }
 
 /* Test reduce_otherrelhealth */
@@ -136,12 +117,9 @@ replace reduce_parenthealth = 1.0
 replace reduce_otherrelhealth = 0.1
 save assumptions, replace
 do "run_anyassumptions.do"
-gen pass_redotherrel_expben = (abs(expectedbenefit - 309.5474) < 0.01)
-gen pass_redotherrel_total = (abs(totalcost/10^9 - 49.29946) < 0.01)
-gen pass_redotherrel_payroll = (abs(payrollcost*100 - .57046711) < 0.01)
-drop expectedbenefit totalcost payrollcost
-gen mergeid = 1
-save "tests/test_output/test_assum_redotherrel_output.dta", replace
+gen testid = "reduce_otherrelhealth"
+merge 1:1 testid using "tests/test_output/test_assum_output.dta", nogen
+save "tests/test_output/test_assum_output.dta", replace
 }
 
 /* Test reduce_military */
@@ -151,12 +129,9 @@ replace reduce_otherrelhealth = 1.0
 replace reduce_military = 0.9
 save assumptions, replace
 do "run_anyassumptions.do"
-gen pass_redmilitary_expben = (abs(expectedbenefit - 312.691) < 0.01)
-gen pass_redmilitary_total = (abs(totalcost/10^9 - 49.80011) < 0.01)
-gen pass_redmilitary_payroll = (abs(payrollcost*100 - .57626031) < 0.01)
-drop expectedbenefit totalcost payrollcost
-gen mergeid = 1
-save "tests/test_output/test_assum_redmilitary_output.dta", replace
+gen testid = "reduce_military"
+merge 1:1 testid using "tests/test_output/test_assum_output.dta", nogen
+save "tests/test_output/test_assum_output.dta", replace
 }
 
 /* Test reduce_otherreason */
@@ -166,12 +141,9 @@ replace reduce_military = 1.0
 replace reduce_otherreason = 0.0
 save assumptions, replace
 do "run_anyassumptions.do"
-gen pass_redother_expben = (abs(expectedbenefit - 312.1819) < 0.01)
-gen pass_redother_total = (abs(totalcost/10^9 - 49.719038) < 0.01)
-gen pass_redother_payroll = (abs(payrollcost*100 - .57532224) < 0.01)
-drop expectedbenefit totalcost payrollcost
-gen mergeid = 1
-save "tests/test_output/test_assum_redother_output.dta", replace
+gen testid = "reduce_otherreason"
+merge 1:1 testid using "tests/test_output/test_assum_output.dta", nogen
+save "tests/test_output/test_assum_output.dta", replace
 }
 
 /* Test reduce_newchild */
@@ -181,12 +153,9 @@ replace reduce_otherreason = 1.0
 replace reduce_newchild = 0.9
 save assumptions, replace
 do "run_anyassumptions.do"
-gen pass_rednewchild_expben = (abs(expectedbenefit - 305.1873) < 0.01)
-gen pass_rednewchild_total = (abs(totalcost/10^9 - 48.605061) < 0.01)
-gen pass_rednewchild_payroll = (abs(payrollcost*100 - .5624319) < 0.01)
-drop expectedbenefit totalcost payrollcost
-gen mergeid = 1
-save "tests/test_output/test_assum_rednewchild_output.dta", replace
+gen testid = "reduce_newchild"
+merge 1:1 testid using "tests/test_output/test_assum_output.dta", nogen
+save "tests/test_output/test_assum_output.dta", replace
 }
 
 /* Test frac_fullpush and frac_partialpush */
@@ -197,12 +166,9 @@ replace frac_fullpush = 0.4
 replace frac_partialpush = 0.6
 save assumptions, replace
 do "run_anyassumptions.do"
-gen pass_emppush_expben = (abs(expectedbenefit - 247.8717) < 0.01)
-gen pass_emppush_total = (abs(totalcost/10^9 - 39.476793) < 0.01)
-gen pass_emppush_payroll = (abs(payrollcost*100 - .45680446) < 0.01)
-drop expectedbenefit totalcost payrollcost
-gen mergeid = 1
-save "tests/test_output/test_assum_emppush_output.dta", replace
+gen testid = "push"
+merge 1:1 testid using "tests/test_output/test_assum_output.dta", nogen
+save "tests/test_output/test_assum_output.dta", replace
 }
 
 /* Test delay_partialpush */
@@ -211,123 +177,35 @@ use assumptions, clear
 replace delay_partialpush = 25
 save assumptions, replace
 do "run_anyassumptions.do"
-gen pass_delay_expben = (abs(expectedbenefit - 237.6747) < 0.01)
-gen pass_delay_total = (abs(totalcost/10^9 - 37.852791) < 0.01)
-gen pass_delay_payroll = (abs(payrollcost*100 - .43801232) < 0.01)
+gen testid = "delay_partialpush"
+merge 1:1 testid using "tests/test_output/test_assum_output.dta", nogen
+save "tests/test_output/test_assum_output.dta", replace
+}
+
+/* ONLY USE TO OVERWRITE RESULTS
+// Export results to CSV file
+use "tests/test_output/test_assum_output.dta", clear
+gen expectedbenefit_res = round(expectedbenefit, 0.01)
+gen totalcost_res = round(totalcost / 10^9, 0.01)
+gen payrollcost_res = round(payrollcost * 100, 0.01)
 drop expectedbenefit totalcost payrollcost
-gen mergeid = 1
-save "tests/test_output/test_assum_delay_output.dta", replace
-}
+export delimited expectedbenefit_res totalcost_res payrollcost_res testid using "tests/test_output/testresults_assumptions.csv", replace
+di "Test assumptions results saved"
+*/
 
-/* Check that all tests pass, or which fail */
-quietly{
-use "tests/test_output/test_assum_basecase_output.dta", clear
-gen pass_basecase = pass_basecase_expben * pass_basecase_total * pass_basecase_payroll
-if pass_basecase==1 {
-noisily di "Base case passes"
+/* Check that all tests pass or which fail */
+quietly {
+import delimited "tests/test_output/testresults_assumptions.csv", clear
+merge 1:1 testid using "tests/test_output/test_assum_output.dta"
+replace expectedbenefit = round(expectedbenefit, 0.01)
+replace totalcost = round(totalcost / 10^9, 0.01)
+replace payrollcost = round(payrollcost * 100, 0.01)
+gen pass_expben = (expectedbenefit==expectedbenefit_res)
+gen pass_total = (totalcost==totalcost_res)
+gen pass_payroll = (payrollcost==payrollcost_res)
+gen pass_test = pass_expben * pass_total * pass_payroll
+gen test_message = ""
+replace test_message = testid + ": " + "PASS" if pass_test==1
+replace test_message = testid + ": " + "FAIL" if pass_test==0
+noisily list test_message
 }
-else {
-noisily di "Base case fails"
-noisily sum pass_basecase_expben pass_basecase_total pass_basecase_payroll
-}
-merge 1:1 mergeid using "tests/test_output/test_assum_takeup_output.dta", nogen norep
-gen pass_takeup = pass_takeup_expben * pass_takeup_total * pass_takeup_payroll
-if pass_takeup == 1 {
-noisily di "Overall take-up assumption passes"
-}
-else {
-noisily di "Overall take-up assumption fails"
-noisily sum pass_takeup_expben pass_takeup_total pass_takeup_payroll
-}
-merge 1:1 mergeid using "tests/test_output/test_assum_redmedical_output.dta", nogen norep
-gen pass_redmedical = pass_redmedical_expben * pass_redmedical_total * pass_redmedical_payroll
-if pass_redmedical == 1 {
-noisily di "Reduce take-up for ownhealth assumption passes"
-}
-else {
-noisily di "Reduce take-up for ownhealth assumption fails"
-noisily sum pass_redmedical_expben pass_redmedical_total pass_redmedical_payroll
-}
-merge 1:1 mergeid using "tests/test_output/test_assum_redchildh_output.dta", nogen norep
-gen pass_redchildh = pass_redchildh_expben * pass_redchildh_total * pass_redchildh_payroll
-if pass_redchildh == 1 {
-noisily di "Reduce take-up for child health assumption passes"
-}
-else {
-noisily di "Reduce take-up for child health assumption fails"
-noisily sum pass_redchildh_expben pass_redchildh_total pass_redchildh_payroll
-}
-merge 1:1 mergeid using "tests/test_output/test_assum_redspouse_output.dta", nogen norep
-gen pass_redspouse = pass_redspouse_expben * pass_redspouse_total * pass_redspouse_payroll
-if pass_redspouse == 1 {
-noisily di "Reduce take-up for spouse health assumption passes"
-}
-else {
-noisily di "Reduce take-up for spouse health assumption fails"
-noisily sum pass_redspouse_expben pass_redspouse_total pass_redspouse_payroll
-}
-merge 1:1 mergeid using "tests/test_output/test_assum_redparent_output.dta", nogen norep
-gen pass_redparent = pass_redparent_expben * pass_redparent_total * pass_redparent_payroll
-if pass_redparent == 1 {
-noisily di "Reduce take-up for parent health assumption passes"
-}
-else {
-noisily di "Reduce take-up for parent health assumption fails"
-noisily sum pass_redparent_expben pass_redparent_total pass_redparent_payroll
-}
-merge 1:1 mergeid using "tests/test_output/test_assum_redotherrel_output.dta", nogen norep
-gen pass_redotherrel = pass_redotherrel_expben * pass_redotherrel_total * pass_redotherrel_payroll
-if pass_redotherrel == 1 {
-noisily di "Reduce take-up for other relative health assumption passes"
-}
-else {
-noisily di "Reduce take-up for other relative health assumption fails"
-noisily sum pass_redotherrel_expben pass_redotherrel_total pass_redotherrel_payroll
-}
-merge 1:1 mergeid using "tests/test_output/test_assum_redmilitary_output.dta", nogen norep
-gen pass_redmilitary = pass_redmilitary_expben * pass_redmilitary_total * pass_redmilitary_payroll
-if pass_redmilitary == 1 {
-noisily di "Reduce take-up for military assumption passes"
-}
-else {
-noisily di "Reduce take-up for military assumption fails"
-noisily sum pass_redmilitary_expben pass_redmilitary_total pass_redmilitary_payroll
-}
-merge 1:1 mergeid using "tests/test_output/test_assum_redother_output.dta", nogen norep
-gen pass_redother = pass_redother_expben * pass_redother_total * pass_redother_payroll
-if pass_redother == 1 {
-noisily di "Reduce take-up for other reason assumption passes"
-}
-else {
-noisily di "Reduce take-up for other reason assumption fails"
-noisily sum pass_redother_expben pass_redother_total pass_redother_payroll
-}
-merge 1:1 mergeid using "tests/test_output/test_assum_rednewchild_output.dta", nogen norep
-gen pass_rednewchild = pass_rednewchild_expben * pass_rednewchild_total * pass_rednewchild_payroll
-if pass_rednewchild == 1 {
-noisily di "Reduce take-up for new child assumption passes"
-}
-else {
-noisily di "Reduce take-up for new child assumption fails"
-noisily sum pass_rednewchild_expben pass_rednewchild_total pass_rednewchild_payroll
-}
-merge 1:1 mergeid using "tests/test_output/test_assum_emppush_output.dta", nogen norep
-gen pass_emppush = pass_emppush_expben * pass_emppush_total * pass_emppush_payroll
-if pass_emppush == 1 {
-noisily di "Reduced employer push assumption passes"
-}
-else {
-noisily di "Reduced employer push assumption fails"
-noisily sum pass_emppush_expben pass_emppush_total pass_emppush_payroll
-}
-merge 1:1 mergeid using "tests/test_output/test_assum_delay_output.dta", nogen norep
-gen pass_delay = pass_delay_expben * pass_delay_total * pass_delay_payroll
-if pass_delay == 1 {
-noisily di "Employer push delay assumption passes"
-}
-else {
-noisily di "Employer push delay assumption fails"
-noisily sum pass_delay_expben pass_delay_total pass_delay_payroll
-}
-}
-

--- a/tests/test_output/.gitignore
+++ b/tests/test_output/.gitignore
@@ -1,2 +1,4 @@
 *
 !.gitignore
+!testresults_assumptions.csv
+!testresults_parameters.csv

--- a/tests/test_output/testresults_assumptions.csv
+++ b/tests/test_output/testresults_assumptions.csv
@@ -1,0 +1,13 @@
+expectedbenefit_res,totalcost_res,payrollcost_res,testid
+237.67,37.849998,.44,delay_partialpush
+313.13,49.869999,.57999998,base_case
+393.88,62.73,.73000002,overall_takeup
+247.87,39.48,.46000001,push
+307.39999,48.959999,.56999999,reduce_childhealth
+312.69,49.799999,.57999998,reduce_military
+305.19,48.610001,.56,reduce_newchild
+312.17999,49.720001,.57999998,reduce_otherreason
+309.54999,49.299999,.56999999,reduce_otherrelhealth
+220.10001,35.049999,.41,reduce_ownhealth
+298.73999,47.580002,.55000001,reduce_parenthealth
+301.07999,47.950001,.55000001,reduce_spousehealth

--- a/tests/test_output/testresults_parameters.csv
+++ b/tests/test_output/testresults_parameters.csv
@@ -1,0 +1,17 @@
+expectedbenefit_res,totalcost_res,payrollcost_res,testid
+233.67,37.209999,.43000001,include_newchild
+313.13,49.869999,.57999998,base_case
+305.95999,48.73,.56,include_childhealth
+308.70001,49.169998,.56999999,include_military
+312.17999,49.720001,.57999998,include_otherreason
+309.14999,49.240002,.56999999,include_otherrelhealth
+127.07,20.24,.23,include_ownhealth
+297.14001,47.32,.55000001,include_parenthealth
+298.06,47.470001,.55000001,include_spousehealth
+399.60001,63.639999,.74000001,maxbenefit
+411.76999,65.580002,.75999999,maxduration_days
+332.5,52.950001,.61000001,minbenefit
+297.37,47.360001,.55000001,phase_out
+341.87,54.450001,.63,replacementrate
+264.39001,42.110001,.49000001,waiting_period
+297.45001,47.369999,.55000001,work_requirement

--- a/tests/test_parameters.do
+++ b/tests/test_parameters.do
@@ -48,12 +48,8 @@ save assumptions, replace
 /* Test base case*/
 quietly {
 do "run_anyassumptions.do"
-gen pass_basecase_expben = (abs(expectedbenefit - 313.13403) < 0.01)
-gen pass_basecase_total = (abs(totalcost/10^9 - 49.870676) < 0.01)
-gen pass_basecase_payroll = (abs(payrollcost*100 - 0.5770769) < 0.01)
-drop expectedbenefit totalcost payrollcost
-gen mergeid = 1
-save "tests/test_output/test_params_basecase_output.dta", replace
+gen testid = "base_case"
+save "tests/test_output/test_params_output.dta", replace
 }
 
 /* Test maxduration_days */
@@ -62,12 +58,9 @@ use parameters, clear
 replace maxduration_days = 80
 save parameters, replace
 do "run_anyassumptions.do"
-gen pass_duration_expben = (abs(expectedbenefit - 411.77203) < 0.01)
-gen pass_duration_total = (abs(totalcost/10^9 - 65.580061) < 0.01)
-gen pass_duration_payroll = (abs(payrollcost*100 - 0.75885751) < 0.01)
-drop expectedbenefit totalcost payrollcost
-gen mergeid = 1
-save "tests/test_output/test_params_duration_output.dta", replace
+gen testid = "maxduration_days"
+merge 1:1 testid using "tests/test_output/test_params_output.dta", nogen
+save "tests/test_output/test_params_output.dta", replace
 }
 
 /* Test replacementrate */
@@ -77,12 +70,9 @@ replace maxduration_days = 40
 replace replacementrate = 0.9
 save parameters, replace
 do "run_anyassumptions.do"
-gen pass_replacement_expben = (abs(expectedbenefit - 341.86853) < 0.01)
-gen pass_replacement_total = (abs(totalcost/10^9 - 54.447018) < 0.01)
-gen pass_replacement_payroll = (abs(payrollcost*100 - 0.6300319) < 0.01)
-drop expectedbenefit totalcost payrollcost
-gen mergeid = 1
-save "tests/test_output/test_params_replacement_output.dta", replace
+gen testid = "replacementrate"
+merge 1:1 testid using "tests/test_output/test_params_output.dta", nogen
+save "tests/test_output/test_params_output.dta", replace
 }
 
 /* Test maxbenefit */
@@ -91,13 +81,10 @@ use parameters, clear
 replace replacementrate = 0.7
 replace maxbenefit = 1000
 save parameters, replace
-quietly do "run_anyassumptions.do"
-gen pass_maxben_expben = (abs(expectedbenefit - 399.59793) < 0.01)
-gen pass_maxben_total = (abs(totalcost/10^9 - 63.641178) < 0.01)
-gen pass_maxben_payroll = (abs(payrollcost*100 - 0.73642181) < 0.01)
-drop expectedbenefit totalcost payrollcost
-gen mergeid = 1
-save "tests/test_output/test_params_maxben_output.dta", replace
+do "run_anyassumptions.do"
+gen testid = "maxbenefit"
+merge 1:1 testid using "tests/test_output/test_params_output.dta", nogen
+save "tests/test_output/test_params_output.dta", replace
 }
 
 /* Test minbenefit */
@@ -106,13 +93,10 @@ use parameters, clear
 replace maxbenefit = 600
 replace minbenefit = 300
 save parameters, replace
-quietly do "run_anyassumptions.do"
-gen pass_minben_expben = (abs(expectedbenefit - 332.49939) < 0.01)
-gen pass_minben_total = (abs(totalcost/10^9 - 52.954862) < 0.01)
-gen pass_minben_payroll = (abs(payrollcost*100 - .61276546) < 0.01)
-drop expectedbenefit totalcost payrollcost
-gen mergeid = 1
-save "tests/test_output/test_params_minben_output.dta", replace
+do "run_anyassumptions.do"
+gen testid = "minbenefit"
+merge 1:1 testid using "tests/test_output/test_params_output.dta", nogen
+save "tests/test_output/test_params_output.dta", replace
 }
 
 /* Test phase-out */
@@ -122,13 +106,10 @@ replace minbenefit = 0
 replace benefit_phaseout_thd = 2000
 replace benefit_phaseout_rt = 0.2
 save parameters, replace
-quietly do "run_anyassumptions.do"
-gen pass_phaseout_expben = (abs(expectedbenefit - 297.36621) < 0.01)
-gen pass_phaseout_total = (abs(totalcost/10^9 - 47.359439) < 0.01)
-gen pass_phaseout_payroll = (abs(payrollcost*100 - .54801819) < 0.01)
-drop expectedbenefit totalcost payrollcost
-gen mergeid = 1
-save "tests/test_output/test_params_phaseout_output.dta", replace
+do "run_anyassumptions.do"
+gen testid = "phase_out"
+merge 1:1 testid using "tests/test_output/test_params_output.dta", nogen
+save "tests/test_output/test_params_output.dta", replace
 }
 
 /* Test waiting_period */
@@ -138,13 +119,10 @@ replace benefit_phaseout_thd = 9e99
 replace benefit_phaseout_rt = 0
 replace waiting_period = 5
 save parameters, replace
-quietly do "run_anyassumptions.do"
-gen pass_waiting_expben = (abs(expectedbenefit - 264.39389) < 0.01)
-gen pass_waiting_total = (abs(totalcost/10^9 - 42.10817) < 0.01)
-gen pass_waiting_payroll = (abs(payrollcost*100 - 0.48725335) < 0.01)
-drop expectedbenefit totalcost payrollcost
-gen mergeid = 1
-save "tests/test_output/test_params_waiting_output.dta", replace
+do "run_anyassumptions.do"
+gen testid = "waiting_period"
+merge 1:1 testid using "tests/test_output/test_params_output.dta", nogen
+save "tests/test_output/test_params_output.dta", replace
 }
 
 /* Test work_requirement */
@@ -153,13 +131,10 @@ use parameters, clear
 replace waiting_period = 0
 replace work_requirement = 1000
 save parameters, replace
-quietly do "run_anyassumptions.do"
-gen pass_workhrs_expben = (abs(expectedbenefit - 297.452) < 0.01)
-gen pass_workhrs_total = (abs(totalcost/10^9 - 47.373103) < 0.01)
-gen pass_workhrs_payroll = (abs(payrollcost*100 - .54817633) < 0.01)
-drop expectedbenefit totalcost payrollcost
-gen mergeid = 1
-save "tests/test_output/test_params_workhrs_output.dta", replace
+do "run_anyassumptions.do"
+gen testid = "work_requirement"
+merge 1:1 testid using "tests/test_output/test_params_output.dta", nogen
+save "tests/test_output/test_params_output.dta", replace
 }
 
 /* Test include_ownhealth */
@@ -168,13 +143,10 @@ use parameters, clear
 replace work_requirement = 0
 replace include_ownhealth = 0
 save parameters, replace
-quietly do "run_anyassumptions.do"
-gen pass_ownhealth_expben = (abs(expectedbenefit - 127.06824) < 0.01)
-gen pass_ownhealth_total = (abs(totalcost/10^9 - 20.237271) < 0.01)
-gen pass_ownhealth_payroll = (abs(payrollcost*100 - .23417494) < 0.01)
-drop expectedbenefit totalcost payrollcost
-gen mergeid = 1
-save "tests/test_output/test_params_ownhealth_output.dta", replace
+do "run_anyassumptions.do"
+gen testid = "include_ownhealth"
+merge 1:1 testid using "tests/test_output/test_params_output.dta", nogen
+save "tests/test_output/test_params_output.dta", replace
 }
 
 /* Test include_childhealth */
@@ -183,13 +155,10 @@ use parameters, clear
 replace include_ownhealth = 1
 replace include_childhealth = 0
 save parameters, replace
-quietly do "run_anyassumptions.do"
-gen pass_childhealth_expben = (abs(expectedbenefit - 305.9642) < 0.01)
-gen pass_childhealth_total = (abs(totalcost/10^9 - 48.728785) < 0.01)
-gen pass_childhealth_payroll = (abs(payrollcost*100 - .56386353) < 0.01)
-drop expectedbenefit totalcost payrollcost
-gen mergeid = 1
-save "tests/test_output/test_params_childhealth_output.dta", replace
+do "run_anyassumptions.do"
+gen testid = "include_childhealth"
+merge 1:1 testid using "tests/test_output/test_params_output.dta", nogen
+save "tests/test_output/test_params_output.dta", replace
 }
 
 /* Test include_spousehealth */
@@ -198,13 +167,10 @@ use parameters, clear
 replace include_childhealth = 1
 replace include_spousehealth = 0
 save parameters, replace
-quietly do "run_anyassumptions.do"
-gen pass_spousehealth_expben = (abs(expectedbenefit - 298.06427) < 0.01)
-gen pass_spousehealth_total = (abs(totalcost/10^9 - 47.470617) < 0.01)
-gen pass_spousehealth_payroll = (abs(payrollcost*100 - .54930467) < 0.01)
-drop expectedbenefit totalcost payrollcost
-gen mergeid = 1
-save "tests/test_output/test_params_spousehealth_output.dta", replace
+do "run_anyassumptions.do"
+gen testid = "include_spousehealth"
+merge 1:1 testid using "tests/test_output/test_params_output.dta", nogen
+save "tests/test_output/test_params_output.dta", replace
 }
 
 /* Test include_parenthealth */
@@ -213,13 +179,10 @@ use parameters, clear
 replace include_spousehealth = 1
 replace include_parenthealth = 0
 save parameters, replace
-quietly do "run_anyassumptions.do"
-gen pass_parenthealth_expben = (abs(expectedbenefit - 297.14026) < 0.01)
-gen pass_parenthealth_total = (abs(totalcost/10^9 - 47.323455) < 0.01)
-gen pass_parenthealth_payroll = (abs(payrollcost*100 - .54760179) < 0.01)
-drop expectedbenefit totalcost payrollcost
-gen mergeid = 1
-save "tests/test_output/test_params_parenthealth_output.dta", replace
+do "run_anyassumptions.do"
+gen testid = "include_parenthealth"
+merge 1:1 testid using "tests/test_output/test_params_output.dta", nogen
+save "tests/test_output/test_params_output.dta", replace
 }
 
 /* Test include_otherrealhealth */
@@ -228,13 +191,10 @@ use parameters, clear
 replace include_parenthealth = 1
 replace include_otherrelhealth = 0
 save parameters, replace
-quietly do "run_anyassumptions.do"
-gen pass_otherrel_expben = (abs(expectedbenefit - 309.1489) < 0.01)
-gen pass_otherrel_total = (abs(totalcost/10^9 - 49.235988) < 0.01)
-gen pass_otherrel_payroll = (abs(payrollcost*100 - .56973263) < 0.01)
-drop expectedbenefit totalcost payrollcost
-gen mergeid = 1
-save "tests/test_output/test_params_otherrel_output.dta", replace
+do "run_anyassumptions.do"
+gen testid = "include_otherrelhealth"
+merge 1:1 testid using "tests/test_output/test_params_output.dta", nogen
+save "tests/test_output/test_params_output.dta", replace
 }
 
 /* Test include_military */
@@ -243,13 +203,10 @@ use parameters, clear
 replace include_otherrelhealth = 1
 replace include_military = 0
 save parameters, replace
-quietly do "run_anyassumptions.do"
-gen pass_military_expben = (abs(expectedbenefit - 308.70319) < 0.01)
-gen pass_military_total = (abs(totalcost/10^9 - 49.165005) < 0.01)
-gen pass_military_payroll = (abs(payrollcost*100 - .56891125) < 0.01)
-drop expectedbenefit totalcost payrollcost
-gen mergeid = 1
-save "tests/test_output/test_params_military_output.dta", replace
+do "run_anyassumptions.do"
+gen testid = "include_military"
+merge 1:1 testid using "tests/test_output/test_params_output.dta", nogen
+save "tests/test_output/test_params_output.dta", replace
 }
 
 /* Test include_otherreason */
@@ -258,13 +215,10 @@ use parameters, clear
 replace include_military = 1
 replace include_otherreason = 0
 save parameters, replace
-quietly do "run_anyassumptions.do"
-gen pass_other_expben = (abs(expectedbenefit - 312.18195) < 0.01)
-gen pass_other_total = (abs(totalcost/10^9 - 49.719038) < 0.01)
-gen pass_other_payroll = (abs(payrollcost*100 - .57532224) < 0.01)
-drop expectedbenefit totalcost payrollcost
-gen mergeid = 1
-save "tests/test_output/test_params_other_output.dta", replace
+do "run_anyassumptions.do"
+gen testid = "include_otherreason"
+merge 1:1 testid using "tests/test_output/test_params_output.dta", nogen
+save "tests/test_output/test_params_output.dta", replace
 }
 
 /* Test include_newchild */
@@ -273,161 +227,36 @@ use parameters, clear
 replace include_otherreason = 1
 replace include_newchild = 0
 save parameters, replace
-quietly do "run_anyassumptions.do"
-gen pass_newchild_expben = (abs(expectedbenefit - 233.6673) < 0.01)
-gen pass_newchild_total = (abs(totalcost/10^9 - 37.21456) < 0.01)
-gen pass_newchild_payroll = (abs(payrollcost*100 - .43062707) < 0.01)
+do "run_anyassumptions.do"
+gen testid = "include_newchild"
+merge 1:1 testid using "tests/test_output/test_params_output.dta", nogen
+save "tests/test_output/test_params_output.dta", replace
+}
+
+/* ONLY USE TO OVERWRITE RESULTS
+// Export results to CSV file
+use "tests/test_output/test_params_output.dta", clear
+gen expectedbenefit_res = round(expectedbenefit, 0.01)
+gen totalcost_res = round(totalcost / 10^9, 0.01)
+gen payrollcost_res = round(payrollcost * 100, 0.01)
 drop expectedbenefit totalcost payrollcost
-gen mergeid = 1
-save "tests/test_output/test_params_newchild_output.dta", replace
-}
+export delimited expectedbenefit_res totalcost_res payrollcost_res testid using "tests/test_output/testresults_parameters.csv", replace
+*/
 
-/* Check that all tests pass, or which fail */
-quietly{
-use "tests/test_output/test_params_basecase_output.dta", clear
-gen pass_basecase = pass_basecase_expben * pass_basecase_total * pass_basecase_payroll
-if pass_basecase==1 {
-noisily di "Base case passes"
+/* Check that all tests pass or which fail */
+quietly {
+import delimited "tests/test_output/testresults_parameters.csv", clear
+merge 1:1 testid using "tests/test_output/test_params_output.dta"
+replace expectedbenefit = round(expectedbenefit, 0.01)
+replace totalcost = round(totalcost / 10^9, 0.01)
+replace payrollcost = round(payrollcost * 100, 0.01)
+gen pass_expben = (expectedbenefit==expectedbenefit_res)
+gen pass_total = (totalcost==totalcost_res)
+gen pass_payroll = (payrollcost==payrollcost_res)
+gen pass_test = pass_expben * pass_total * pass_payroll
+gen test_message = ""
+replace test_message = testid + ": " + "PASS" if pass_test==1
+replace test_message = testid + ": " + "FAIL" if pass_test==0
+noisily list test_message
 }
-else {
-noisily di "Base case fails"
-noisily sum pass_basecase_expben pass_basecase_total pass_basecase_payroll
-}
-merge 1:1 mergeid using "tests/test_output/test_params_duration_output.dta", nogen norep
-gen pass_duration = pass_duration_expben * pass_duration_total * pass_duration_payroll
-if pass_duration == 1 {
-noisily di "Duration parameter passes"
-}
-else {
-noisily di "Duration parameter fails"
-noisily sum pass_duration_expben pass_duration_total pass_duration_payroll
-}
-merge 1:1 mergeid using "tests/test_output/test_params_replacement_output.dta", nogen norep
-gen pass_replacement = pass_replacement_expben * pass_replacement_total * pass_replacement_payroll
-if pass_replacement == 1 {
-noisily di "Replacement rate parameter passes"
-}
-else {
-noisily di "Replacement rate parameter fails"
-noisily sum pass_replacement_expben pass_replacement_total pass_replacement_payroll
-}
-merge 1:1 mergeid using "tests/test_output/test_params_maxben_output.dta", nogen norep
-gen pass_maxben = pass_maxben_expben * pass_maxben_total * pass_maxben_payroll
-if pass_maxben == 1 {
-noisily di "Maximum benefit parameter passes"
-}
-else {
-noisily di "Maximum benefit parameter fails"
-noisily sum pass_maxben_expben pass_maxben_total pass_maxben_payroll
-}
-merge 1:1 mergeid using "tests/test_output/test_params_minben_output.dta", nogen norep
-gen pass_minben = pass_minben_expben * pass_minben_total * pass_minben_payroll
-if pass_minben == 1 {
-noisily di "Minimum benefit parameter passes"
-}
-else {
-noisily di "Minimum benefit parameter fails"
-noisily sum pass_minben_expben pass_minben_total pass_minben_payroll
-}
-merge 1:1 mergeid using "tests/test_output/test_params_phaseout_output.dta", nogen norep
-gen pass_phaseout = pass_phaseout_expben * pass_phaseout_total * pass_phaseout_payroll
-if pass_phaseout == 1 {
-noisily di "Phase-out parameter(s) passes"
-}
-else {
-noisily di "Phase-out parameter(s) fails"
-noisily sum pass_phaseout_expben pass_phaseout_total pass_phaseout_payroll
-}
-merge 1:1 mergeid using "tests/test_output/test_params_waiting_output.dta", nogen norep
-gen pass_waiting = pass_waiting_expben * pass_waiting_total * pass_waiting_payroll
-if pass_waiting == 1 {
-noisily di "Waiting period parameter passes"
-}
-else {
-noisily di "Waiting period parameter fails"
-noisily sum pass_waiting_expben pass_waiting_total pass_waiting_payroll
-}
-merge 1:1 mergeid using "tests/test_output/test_params_workhrs_output.dta", nogen norep
-gen pass_workhrs = pass_workhrs_expben * pass_workhrs_total * pass_workhrs_payroll
-if pass_workhrs == 1 {
-noisily di "Work hours requirement parameter passes"
-}
-else {
-noisily di "Work hours requirement parameter fails"
-noisily sum pass_workhrs_expben pass_workhrs_total pass_workhrs_payroll
-}
-merge 1:1 mergeid using "tests/test_output/test_params_ownhealth_output.dta", nogen norep
-gen pass_ownhealth = pass_ownhealth_expben * pass_ownhealth_total * pass_ownhealth_payroll
-if pass_ownhealth == 1 {
-noisily di "Include ownh health parameter passes"
-}
-else {
-noisily di "Include own health parameter fails"
-noisily sum pass_ownhealth_expben pass_ownhealth_total pass_ownhealth_payroll
-}
-merge 1:1 mergeid using "tests/test_output/test_params_childhealth_output.dta", nogen norep
-gen pass_childhealth = pass_childhealth_expben * pass_childhealth_total * pass_childhealth_payroll
-if pass_childhealth == 1 {
-noisily di "Include child health parameter passes"
-}
-else {
-noisily di "Include child health parameter fails"
-noisily sum pass_childhealth_expben pass_childhealth_total pass_childhealth_payroll
-}
-merge 1:1 mergeid using "tests/test_output/test_params_spousehealth_output.dta", nogen norep
-gen pass_spousehealth = pass_spousehealth_expben * pass_spousehealth_total * pass_spousehealth_payroll
-if pass_spousehealth == 1 {
-noisily di "Include spouse health parameter passes"
-}
-else {
-noisily di "Include spouse health parameter fails"
-noisily sum pass_spousehealth_expben pass_spousehealth_total pass_spousehealth_payroll
-}
-merge 1:1 mergeid using "tests/test_output/test_params_parenthealth_output.dta", nogen norep
-gen pass_parenthealth = pass_parenthealth_expben * pass_parenthealth_total * pass_parenthealth_payroll
-if pass_parenthealth == 1 {
-noisily di "Include parent health parameter passes"
-}
-else {
-noisily di "Include parent health parameter fails"
-noisily sum pass_parenthealth_expben pass_parenthealth_total pass_parenthealth_payroll
-}
-merge 1:1 mergeid using "tests/test_output/test_params_otherrel_output.dta", nogen norep
-gen pass_otherrel = pass_otherrel_expben * pass_otherrel_total * pass_otherrel_payroll
-if pass_otherrel == 1 {
-noisily di "Include other relative health parameter passes"
-}
-else {
-noisily di "Include other relative health parameter fails"
-noisily sum pass_otherrel_expben pass_otherrel_total pass_otherrel_payroll
-}
-merge 1:1 mergeid using "tests/test_output/test_params_military_output.dta", nogen norep
-gen pass_military = pass_military_expben * pass_military_total * pass_military_payroll
-if pass_military == 1 {
-noisily di "Include military parameter passes"
-}
-else {
-noisily di "Include military parameter fails"
-noisily sum pass_military_expben pass_military_total pass_military_payroll
-}
-merge 1:1 mergeid using "tests/test_output/test_params_other_output.dta", nogen norep
-gen pass_other = pass_other_expben * pass_other_total * pass_other_payroll
-if pass_other == 1 {
-noisily di "Include other reason parameter passes"
-}
-else {
-noisily di "Include other reason parameter fails"
-noisily sum pass_other_expben pass_other_total pass_other_payroll
-}
-merge 1:1 mergeid using "tests/test_output/test_params_newchild_output.dta", nogen norep
-gen pass_newchild = pass_newchild_expben * pass_newchild_total * pass_newchild_payroll
-if pass_newchild == 1 {
-noisily di "Include new child parameter passes"
-}
-else {
-noisily di "Include new child parameter fails"
-noisily sum pass_newchild_expben pass_newchild_total pass_newchild_payroll
-}
-}
-
 


### PR DESCRIPTION
This PR rewrites the tests of the parameters and assumptions. The new version saves the results of the tests in a CSV. This does not change the actual nature of the tests, the outcomes of the tests, or code affecting any other part of PFL-CM. As such, I am merging it in shortly. 